### PR TITLE
조아라 / 6월18일 / 1문제

### DIFF
--- a/ARaC/PGS/배열의원소삭제하기.java
+++ b/ARaC/PGS/배열의원소삭제하기.java
@@ -1,0 +1,17 @@
+import java.util.*;
+class Solution {
+    public List solution(int[] arr, int[] delete_list) {
+        List<Integer> answer = new ArrayList<>();
+        for(int tmp : arr){
+            answer.add(tmp);
+        }
+        
+        for(int tmp : delete_list){
+            int check = answer.indexOf(tmp);
+            if(check != -1){
+                answer.remove(Integer.valueOf(tmp));
+            }
+        }
+        return answer;
+    }
+}


### PR DESCRIPTION
회고:
Integer타입으로 정의된 ArrayList에서 remove 함수 사용시 int 형으로 매개변수를 사용했을 때 out of range 에러 발생했다.
-> ArrayList의 remove 함수의 파라미터 타입을 확인해봤다. 

1. 인덱스로 삭제할 경우
Public E remove (int index)
즉, int형을 파라미터 타입으로 넣을 경우 인덱스로 인식한다.

2. 값으로 삭제할 경우
Public Boolean remove (Object o)
즉, 객체형(Integer)을 파라미터 타입으로 넣을 경우 값으로 인식한다. 

