### PR TITLE
지승우 / 6월 21일 / 1문제

### DIFF
--- a/jeesw/BOJ/Gold/indi_BOJ_11404_플로이드_240622.java
+++ b/jeesw/BOJ/Gold/indi_BOJ_11404_플로이드_240622.java
@@ -1,0 +1,55 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static final int INF = 1000000000;
+    static int n, m;
+    static int[][] graph;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        m = Integer.parseInt(br.readLine());
+
+        graph = new int[n+1][n+1];
+
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (i == j) graph[i][j] = 0;
+                else graph[i][j] = INF;
+            }
+        }
+
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            graph[a][b] = Math.min(graph[a][b], c);
+        }
+
+        floydWarshall();
+    }
+
+    static void floydWarshall() {
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                for (int k = 1; k <= n; k++) {
+                    graph[j][k] = Math.min(graph[j][i] + graph[i][k], graph[j][k]);
+                }
+            }
+        }
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= n; j++) {
+                if (graph[i][j] == INF) sb.append("0 ");
+                else sb.append(graph[i][j]).append(" ");
+            }
+            sb.append("\n");
+        }
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
스터디 32일차 회고!

[공통 문제 Comment]

 - **방 번호**: 방 번호와 숫자 당 개수를 배열에 맵핑해서 해결했습니다.

 전에 PR했던 내용이라 링크로 대신합니다!

 [https://github.com/Ormi5-Algorithm-Study/algorithm-java/pull/3/commits/f7e5bfaaf55be2a58fbc9e3760f3b045d74fab49](url)

[개별 문제 Comment]
 - **플로이드**: Floyd-Warsahll을 이용하여 해결하였습니다.
 [https://www.acmicpc.net/problem/11404](url)
 
 아이디어
 
 Floyd-Warshall: 1~N 번째의 정점을 통해서 가는 최단거리를 DP를 이용하여 갱신하는 방법이다. 우선, N개의 정점을 2차원 배열에 INF(엄청 큰 값)을 맵핑해보자. 각 (i, j)번 째 인덱스가 뜻하는 바는 i -> j로 가는 최단 거리이다. 그 다음 처음 인덱스부터 마지막 인덱스까지 각각을 통해 가는 최단거리를 갱신한다. 각각의 순회동안 인덱스를 k라고 하고 i -> j로 가는 최단거리를 dist(i, j)라고 표현한다면, `dist(i, j) = min(dist(i,j), dist(i,k) + dist(k, j))`로 나타낼 수 있다. 따라서, Floyd-Warshall은 **DP를 이용한** O(n^3)의 시간 복잡도와 O(n^2)의 공간 복잡도를 가지고 있는 **모든 정점부터 모든 정점까지 가는 최단거리**를 구할 수 있는 알고리즘이다.

![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/6f8a7640-5962-44c5-96d6-565faabb53a3)


1. 이 문제에서는 모든 도시의 쌍 (A, B)에 대해서 도시 A에서 B로 가는데 필요한 비용의 최솟값을 구하라고 했으므로 플로이드-와샬 알고리즘이 적합하다고 볼 수 있다. graph의 이차원 배열에 최단거리를 저장하고, 각각의 인덱스에 INF(큰 값)을 채운다.
2. 이 문제에서는 단반향 그래프로 불필요한 간선도 주어지고 각각의 정점을 들리는 경우는 없으므로 graph[i][i] = 0으로 초기화하고, 인덱스 값이 같을 때는 최소값이 들어오도록 한다.
3. 삼중 for문과 `graph[j][k] = Math.min(graph[j][i] + graph[i][k], graph[j][k]);`를 이용하여 DP로 플로이드 와샬을 사용한다.
4. graph에 저장된 값을 출력하되, 해당 값이 INF인 경우엔 0을 출력한다.

시간복잡도 분석
문제에서 최대 100개의 정점(2 ≤ V ≤ 100), 최대 9800개의 간선(E -> 100P2 = 9800)을 가질 수 있음.
첫 초기화 및 최소값이 들어오는 작업에서 O(V^2)만큼, 소요됨.
플로이드 와샬을 수행하며 O(V^3)만큼 소요되고, 출력을 하는 작업에서 O(V^2)만큼 소요됨.
따라서, **O(N^3)**의 시간 복잡도를 갖는 문제 풀이이고 1억번의 작업을 1초라고 본다면 100^3 = 100만번의 작업을 하고 대략 0.01초 언저리의 수행 시간을 갖는다고 볼 수 있음.

후기
플로이드-와샬을 적용하기만 하면 되서 플로이드-와샬 알고리즘을 연습하기 좋은 문제인 것 같습니다! 알고리즘 자체도 이번것은 직관적이라 최단거리 알고리즘 중에 이해하기도 가장 쉬웠던 것 같습니다.

오늘은 토요일!! 주말 재밌고 활기차게 보내시길 바랍니당~!!