### PR TITLE
지승우 / 6월 25일 / 1문제

### DIFF
--- a/jeesw/BOJ/Gold/indi_BOJ_1967_트리의_지름_240625.java
+++ b/jeesw/BOJ/Gold/indi_BOJ_1967_트리의_지름_240625.java
@@ -1,0 +1,70 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int n;
+    static ArrayList<Pair>[] graph;
+    static boolean[] visited;
+    static int maxVal = 0;
+    static int root = 0;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        n = Integer.parseInt(br.readLine());
+        graph = new ArrayList[10001];
+        visited = new boolean[10001];
+
+        for (int i = 0; i <= 10000; i++) {
+            graph[i] = new ArrayList<>();
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int a = Integer.parseInt(st.nextToken());
+            int b = Integer.parseInt(st.nextToken());
+            int c = Integer.parseInt(st.nextToken());
+            graph[a].add(new Pair(b, c));
+            graph[b].add(new Pair(a, c));
+        }
+
+        dfs(1, 0);
+        maxVal = 0;
+        Arrays.fill(visited, false);
+        dfs(root, 0);
+
+        System.out.println(maxVal);
+    }
+
+    static void dfs(int v, int len) {
+        int cnt = 0;
+        for (Pair p : graph[v]) {
+            if (visited[p.first]) cnt++;
+        }
+        if (cnt == graph[v].size()) {
+            if (maxVal < len) {
+                maxVal = len;
+                root = v;
+            }
+            return;
+        }
+        visited[v] = true;
+        for (Pair p : graph[v]) {
+            int next = p.first;
+            if (!visited[next]) {
+                int dist = len + p.second;
+                dfs(next, dist);
+            }
+        }
+        visited[v] = false;
+    }
+
+    static class Pair {
+        int first, second;
+        Pair(int first, int second) {
+            this.first = first;
+            this.second = second;
+        }
+    }
+}


### PR DESCRIPTION
스터디 34일차 회고!

[공통 문제 Comment]
- **키로거**: Linked List를 이용해서 해결하였습니다.

전에 PR했던 내용이라 링크로 대신합니다!
[https://github.com/Ormi5-Algorithm-Study/algorithm-java/pull/6](url)

[개별 문제 Comment]

 - **트리의 지름**: DFS를 두 번 이용해서 해결하였습니다.
 [https://www.acmicpc.net/problem/1967](url)

아이디어

이 문제는 자연수의 거리만 갖고 있으므로 **부분 트리를 이루는 간선들의 합이 최대라면 어떤 정점에서든 긴 거리와 같은 경로를 적어도 한 개 이상 포함한다는 점**과 **최대값은 항상 부모가 없는 정점에서 시작해서 부모가 없는 정점으로 끝난다는 점**에 착안하여 해결할 수 있다.

1. 그래프(트리)는 각 인덱스마다 거리의 누적 합을 저장한다.
2. DFS를 아무 정점으로 시작하여 그 정점으로 부터의 최대 거리를 갖는 끝 정점을 구한다.
3. 2번에서 구한 점은 최대 트리의 시작점이 되고 이 정점으로 부터 DFS를 한번 더 수행하여 최대 거리를 구한다.

![111111](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/72228e9e-d548-4563-a91e-b3fe11c8af2c)

시간 복잡도 분석
DFS가 O(V+E)만큼 소요되는데 두 번 시행되었으므로 2O(V+E) = O(V+E)의 시간 복잡도를 가지는 알고리즘이다.

후기
전에 풀었던 내용과 이름도 같고 심지어 풀이 방법도 같은데 표기된 난이도가 다르네요 ㅋㅋㅋ 워낙 대표적인 문제기도 하니 DFS를 응용하는 문제로 연습하기 좋은 거 같아요!

이 더운 날에 다들 정말 고생 많으십니다! 내일 수업 때 봬용~