### PR TITLE
지승우 / 6월 30일 / 3문제

### DIFF
--- a/jeesw/BOJ/Gold/indi_BOJ_2448_별_찍기_11_240629.java
+++ b/jeesw/BOJ/Gold/indi_BOJ_2448_별_찍기_11_240629.java
@@ -1,0 +1,119 @@
+// 처음에 DP로 풀은 풀이
+
+// 그래프의 크기가 N이라 했을 때
+// 시간복잡도가 O(N)이므로 이상은 없지만,
+// 0 ~ N 까지 모두 저장하는 방식이므로
+// 최대 10까지 간다면 등비수열의 합 공식에 의해
+// 2 * 3072 * 6143 - 1 = 37742591
+// DP로 대략 4천만번 0.4초 가량의 수행 결과를 갖음.
+// 입출력도 고려한다면 0.8초 언저리의 수행이 들어감.
+// (1억번의 수행을 1초라고 계산했을 때임.)
+
+
+// import java.util.Scanner;
+
+// public class Main {
+//     static int N;
+//     static char[][][] dp = new char[3100][6200][10];
+
+//     public static void main(String[] args) {
+//         Scanner scanner = new Scanner(System.in);
+//         N = scanner.nextInt();
+
+//         int lev = 1;
+
+//         while (N > 3) {
+//             N /= 2;
+//             lev++;
+//         }
+
+//         dp[0][2][0] = '*';
+//         dp[1][1][0] = '*';
+//         dp[1][3][0] = '*';
+//         for (int i = 0; i < 5; i++) {
+//             dp[2][i][0] = '*';
+//         }
+
+//         for (int i = 1; i < lev; i++) {
+//             int x = 6 * (int)Math.pow(2, i - 1) - 1;
+//             int y = 3 * (int)Math.pow(2, i - 1);
+//             for (int j = 0; j < y; j++) {
+//                 for (int k = 0; k < x; k++) {
+//                     int tmp = (int)Math.pow(2, i - 1);
+//                     dp[j][3 * tmp + k][i] = dp[j][k][i - 1];
+//                     dp[3 * tmp + j][k][i] = dp[j][k][i - 1];
+//                     dp[3 * tmp + j][6 * tmp + k][i] = dp[j][k][i - 1];
+//                 }
+//             }
+//         }
+
+//         int xx = 6 * (int)Math.pow(2, lev - 1) - 1;
+//         int yy = 3 * (int)Math.pow(2, lev - 1);
+
+//         StringBuilder sb = new StringBuilder();
+//         for (int i = 0; i < yy; i++) {
+//             for (int j = 0; j < xx; j++) {
+//                 if (dp[i][j][lev - 1] == '\0') {
+//                     sb.append(' ');
+//                 } else {
+//                     sb.append(dp[i][j][lev - 1]);
+//                 }
+//             }
+//             sb.append("\n");
+//         }
+
+//         System.out.print(sb.toString());
+//         scanner.close();
+//     }
+// }
+
+
+
+import java.util.Scanner;
+import java.util.Arrays;
+
+public class Main {
+    static int N;
+    static char[][] stars;
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+        N = scanner.nextInt();
+        stars = new char[N][N * 2];
+
+        for (int i = 0; i < N; i++) {
+            Arrays.fill(stars[i], ' ');
+        }
+
+        makeStarTree(N, 0, 0);
+
+        for (int i = 0; i < N; i++) {
+            System.out.println(new String(stars[i]));
+        }
+
+        scanner.close();
+    }
+
+    static void printStar(int x, int y) {
+        stars[x + 0][y + 2] = '*';
+
+        stars[x + 1][y + 1] = '*';
+        stars[x + 1][y + 3] = '*';
+
+        stars[x + 2][y + 0] = '*';
+        stars[x + 2][y + 1] = '*';
+        stars[x + 2][y + 2] = '*';
+        stars[x + 2][y + 3] = '*';
+        stars[x + 2][y + 4] = '*';
+    }
+
+    static void makeStarTree(int n, int x, int y) {
+        if (n == 3) {
+            printStar(x, y);
+            return;
+        }
+        makeStarTree(n / 2, x, y + n / 2);
+        makeStarTree(n / 2, x + n / 2, y);
+        makeStarTree(n / 2, x + n / 2, y + n);
+    }
+}

--- a/jeesw/BOJ/Gold/pub_BOJ_2493_탑_240629.java
+++ b/jeesw/BOJ/Gold/pub_BOJ_2493_탑_240629.java
@@ -1,0 +1,42 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N;
+    static Stack<Pair> stk = new Stack<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        N = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < N; i++) {
+            int tmp = Integer.parseInt(st.nextToken());
+
+            while (!stk.empty() && tmp > stk.peek().second) {
+                stk.pop();
+            }
+            if (stk.empty()) {
+                bw.write("0 ");
+            } else {
+                bw.write(stk.peek().first + " ");
+            }
+            stk.push(new Pair(i + 1, tmp));
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static class Pair {
+        int first, second;
+
+        Pair(int first, int second) {
+            this.first = first;
+            this.second = second;
+        }
+    }
+}

--- a/jeesw/BOJ/Silver/indi_BOJ_9465_스티커_240630.java
+++ b/jeesw/BOJ/Silver/indi_BOJ_9465_스티커_240630.java
@@ -1,0 +1,50 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int[][] dp = new int[100000][2];
+    static int[][] val = new int[100000][2];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+        StringTokenizer st;
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int test_case = 0; test_case < T; test_case++) {
+            int n = Integer.parseInt(br.readLine());
+
+            for (int i = 0; i < 2; i++) {
+                st = new StringTokenizer(br.readLine());
+                for (int j = 0; j < n; j++) {
+                    val[j][i] = Integer.parseInt(st.nextToken());
+                }
+            }
+
+            dp[n - 1][0] = val[n - 1][0];
+            dp[n - 1][1] = val[n - 1][1];
+
+            if (n >= 2) {
+                dp[n - 2][0] = Math.max(val[n - 1][0], val[n - 2][0] + val[n - 1][1]);
+                dp[n - 2][1] = Math.max(val[n - 1][1], val[n - 2][1] + val[n - 1][0]);
+            }
+
+            if (n >= 3) {
+                for (int i = n - 3; i >= 1; i--) {
+                    dp[i][0] = Math.max(val[i][0] + dp[i + 1][1], val[i + 1][0] + dp[i + 2][1]);
+                    dp[i][1] = Math.max(val[i][1] + dp[i + 1][0], val[i + 1][1] + dp[i + 2][0]);
+                }
+
+                dp[0][0] = val[0][0] + dp[1][1];
+                dp[0][1] = val[0][1] + dp[1][0];
+            }
+
+            bw.write(Math.max(dp[0][0], dp[0][1]) + "\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}


### PR DESCRIPTION
스터디 38일차 회고!

[공통 문제 Comment]
 - **스택 수열**: 스택을 이용해서 해결하였습니다!
 
 전에 PR한 내용이라 링크로 대신하겠습니다.
 [https://github.com/Ormi5-Algorithm-Study/algorithm-java/pull/12](url)

 - **탑**: 스택을 이용해서 해결하였습니다!

아이디어
1. 큰 값과 큰 값 사이의 작은 값은 다음 수행에 영향을 주지 않는다는 점에 착안하여 스택에 인덱스와 값을 쌍으로 저장함.
2. 즉, 스택에는 stk[i] < stk[i + 1] 의 형태로 값이 들어야 한다는 뜻임.
3. 위의 과정을 구현하는 단계. 현재 인덱스에서 값을 입력 받을 때, 스택이 비게되거나, 스택의 top이 지금의 값보다 클 때까지 pop하고 top의 인덱스를 출력하고 현재의 값 push.
 
![111111](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/6541b428-5a17-4ff6-8850-94c8e6420dbd)

시간 복잡도 분석
N개의 탑이 들어온다면, N번 반복하므로 O(N)임.
스택에는 N보다 더 많이 push, pop하는 과정이 없으므로 O(N)으로 취급.
탑 수행을 N번 반복하는 것과 스택의 수행을 반복하는 것은 독립적이므로 둘을 더함.
O(N) + O(N) = O(N)이므로 이 알고리즘의 시간 복잡도는 O(N)임.
또, 최악의 조건 N이 50만개가 들어와도 2*50만 = 100만번 반복함. 1억의 수행을 1초로 본다면, 입출력과 기타 작업을 고려해도 0.04초 언저리에 수행이 끝남.

후기
스택 문제도 생각보다 쉽지 않네요. 후위 연산자 문제 풀 때의 악몽이 떠올랐습니다.

![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/65d64da0-9984-4ff4-a304-3fa2ae3f1e1d)

그리고 자바는 같은 알고리즘이여도 메모리 접근 방식 차이인지 c++이랑 효율성 차이가 꽤 많이 나네요.

<br>
<br>
<br>
<br>
<br>

[개별 문제 Comment]

 - **별 찍기 - 11**: 처음에는 DP를 이용하여 해결했고, 나중에 재귀를 이용한 풀이를 보게 되었습니다! (처음에 푼 풀이 분석은 주석 처리 해 두었습니다.)
[https://www.acmicpc.net/problem/2448](url)

아이디어

1. 별든은 절반의 크기의 별을 다음과 같이 3개로 배치하는 식으로 구성되어 있음.
    i) 상단의 별: n / 2 만큼의 여백을 두고 배치.
    ii) 하단 왼쪽의 별: 그대로 배치.
    iii) 하단 오른쪽의 별: 한 칸 여백을 두고 배치.
2. 절반 만큼 수행이 반복되므로, 재귀를 사용하여 나타낼 수 있음.
3. stars 2차원 배열에 결과를 저장할 것이고, 재귀의 마지막은 n=3일 때이고, 이 때, *을 stars 배열에 저장해줌.
4. 재귀는 1과 3을 표현해주어 다음과 같이 나타남.
```
recursion(n, x, y) {
    if (n == 3) 별 그려주고 return;
    recursion(n / 2, x + n / 2, y);
    recursion(n / 2, x, y + n / 2);
    recursion(n / 2, x + n / 2, y + n / 2);
}
```

![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/666bf3c1-c5a6-4cf4-a976-9ddc5f51c5a5)

시간 복잡도 분석
먼저, 재귀의 시간 복잡도는 마스터 정리(Master Theorem)로 정리 할 수 있음.
![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/c63f3604-a7bd-4eb7-86a2-6513038f5397) 
이 문제에서는 N=3*2^k이므로, k를 기준으로 시간복잡도를 하자면, 다음과 같이 나타낼 수 있음.
`T(k) = 3*T(k/2) + k -> O(k^(log2(3)))`
하지만, stars의 크기를 관점으로 시간 복잡도를 분석해 본다면,
가로 배열 크기 = 3*(2^k), 세로 배열 크기 = 6*(2^k)-1 이므로, stars의 크기(가로)*(세로)를 S라고 친다면, O(S)만큼의 시간 복잡도를 가지게 됨.

후기
바로 출력하는 식으로 할 수 있을 줄 알았는데, 여백 때문에 쉽지 않았습니다. 그리고 재귀로 풀 수 있을 줄은 알았는데 재귀 식이 쉽게 떠오르지 않네요. 재귀 풀이를 다른 블로그에서 봤는데 DP로 풀었던 것에서 좀 만 건드리면 됐던걸 알고, 거의 다 왔는데 놓쳐서 아쉬웠습니다. DP풀이는 재귀 풀이의 2배의 시간과 10배의 공간이 소요되는 것을 확인할 수 있었습니다!

![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/1c59eaea-47a4-410e-9fcf-9f2f365bf6b0)
![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/461f34f3-aa80-416f-9cf9-12ce763c0577)

<br>
<br>
<br>
<br>
<br>

 - **스티커**: DP를 이용하여 해결하였습니다!
 [https://www.acmicpc.net/problem/9465](url)

아이디어

1. (x, y)를 고르냐 안고르냐의 문제로 볼 수 있음.
   - 고른다: 고른값을 누적 합에 더한 뒤, 그로 부터 인접한 영역을 제외한 영역에서 최대를 구해야 함.
   - 안고른다: 바로 옆의 값을 누적 합에 더한 뒤, 그로 부터 인접한 영역을 제외한 영역에서 최대를 구해야 함.
3. 오른쪽 끝 부터 누적 합을 저장할 dp[10000][2]를 만듦.
6. 1을 점화식으로 표현하면 다음과 같음.
`dp[x, 0] = max(value[x, 0] + dp[x + 1, 1], value[x + 1, 0] + dp[x + 2, 1])`
`dp[x, 1] = max(value[x, 1] + dp[x + 1, 0], value[x + 1, 1] + dp[x + 2, 0])`
7. 초기 값은 끝인 n-1과 n-2에서 지정해 줌.
`dp[n - 1][0] = val[n - 1][0]`
`dp[n - 1][1] = val[n - 1][1]`
`dp[n - 2][0] = Math.max(val[n - 1][0], val[n - 2][0] + val[n - 1][1])`
`dp[n - 2][1] = Math.max(val[n - 1][1], val[n - 2][1] + val[n - 1][0])`
8. 최대일 때는 max(dp[0][0], dp[0][1]) 임. 그리고 각각은 다음과 같이 구해짐.
`dp[0][0] = val[0][0] + dp[1][1]`
`dp[0][1] = val[0][1] + dp[1][0]`

![222222](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/46684a63-28ec-418a-ae56-d060cdd11d6f)

시간 복잡도 분석
dp를 하는 과정에서 N번 반복이 일어나므로 O(N)의 시간 복잡도를 갖음.

후기
뭔가 더 깔끔하게 정리 될 수 있을 것 같지만 일단은 떠오르지 않아 더 고민해 보거나 다른 분의 코드를 참고해 봐야겠습니다. 좋은 아이디어 있으면 알려주세요!!

<br>
<br>
<br>
<br>
<br>

이런 형식으로 3문제 PR 적어보는 건 처음인데 쉽지 않군요... 정리 잘 하시는 분들 부럽습니다. 오늘 6월 마지막 일요일 잘 보내시고 월요일 화이팅입니다~