### PR TITLE
지승우 / 7월 3일 / 2문제

### DIFF
--- a/jeesw/BOJ/Gold/indi_BOJ_9251_LCS_240703.java
+++ b/jeesw/BOJ/Gold/indi_BOJ_9251_LCS_240703.java
@@ -1,0 +1,26 @@
+import java.util.Scanner;
+
+public class Main {
+    static int[][] dp = new int[1001][1001];
+
+    public static void main(String[] args) {
+        Scanner scanner = new Scanner(System.in);
+
+        String str1 = scanner.next();
+        String str2 = scanner.next();
+
+        for (int i = 1; i <= str1.length(); i++) {
+            for (int j = 1; j <= str2.length(); j++) {
+                if (str1.charAt(i - 1) == str2.charAt(j - 1)) {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                }
+            }
+        }
+
+        System.out.println(dp[str1.length()][str2.length()]);
+
+        scanner.close();
+    }
+}

--- a/jeesw/BOJ/Silver/indi_BOJ_1021_회전하는_큐_240703.java
+++ b/jeesw/BOJ/Silver/indi_BOJ_1021_회전하는_큐_240703.java
@@ -1,0 +1,50 @@
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        
+        int N = sc.nextInt();
+        int M = sc.nextInt();
+        Deque<Integer> dq = new LinkedList<>();
+        int result = 0;
+
+        for (int i = 1; i <= N; i++) {
+            dq.addLast(i);
+        }
+
+        for (int i = 0; i < M; i++) {
+            int tmp = sc.nextInt();
+            int outNum = dq.peekFirst();
+            int mid = (dq.size() - 1) / 2 + 1;
+
+            boolean isLeft = false;
+            int j = 0;
+            for (int num : dq) {
+                if (num == tmp) {
+                    isLeft = j < mid;
+                    break;
+                }
+                j++;
+            }
+
+            while (outNum != tmp) {
+                if (isLeft) {
+                    int pp = dq.pollFirst();
+                    dq.addLast(pp);
+                } else {
+                    int pp = dq.pollLast();
+                    dq.addFirst(pp);
+                }
+
+                outNum = dq.peekFirst();
+                result++;
+            }
+            dq.pollFirst();
+        }
+
+        System.out.println(result);
+        
+        sc.close();
+    }
+}


### PR DESCRIPTION
스터디 41일차 회고!

[공통 문제 Comment]

 - **회전하는 큐**: Deque를 이용하여 해결하였습니다!

아이디어
1. 앞 뒤에서의 연산이 있으므로 Deque에 값을 저장함.
2. 앞 뒤로 보내는 연산이 최소여야 하니 Deque의 중간 보다 적은 곳에 목표 값이 위치한다면 pop_front, push_back을 그렇지 않다면, pop_back, push_front를 수행함.
3. 2번을 이용하여 두번째 줄에 입력 받는 값과 Deque가 일치할 때 까지 push, pop 연산을 하며 count를 더해 줌.
4. 이것을 M번 반복하면 count가 최종 push, pop 연산 개수가 됨.

시간 복잡도 분석
M개의 입력 만큼 반복하고, 그 안에서 Deque의 개수 만큼 수행이있고, Deque은 N에 비례하므로, O(m) X O(n) = O(mn) 만큼의 시간 복잡도를 갖음.

후기
뭔가 더 효율적으로 코드를 적을 수 있을 것 같다는 생각이 들었습니다! Deque로 풀면 된다는 걸 알아서 더 쉽게 접근 할 수 있었던 것 같습니다!

<br>
<br>
<br>

[개별 문제 Comment]

 - **LCS**: DP를 이용하여 해결습니다!
[https://www.acmicpc.net/problem/9251](url)

아이디어
1. 두 개의 문자열을 받아 각각의 인덱스를 기준으로 가로 세로를 정하고, 각 인덱스 값에 최대 부분 문자열 개수를 넣은 2차원 배열 dp를 만듦.
5. 각 문자열을 가로 세로 순으로 str1, str2라고 하면, 세로열은 str1에서의 최대 부분 문자열 개수를 찾는 것이고, 가로열은 str2에서의 최대 부분 문자열 개수를 찾는 것임.
6. 각 인덱스 값들이 이전 값(2차원 배열에서 왼쪽 값과 위 값)의 최대인 값을 선택하면, 해당 인덱스까지 검사했을 때의 최대 부분 문자열 개수가 나옴.
7. 또 str1의 문자와 str2의 문자가 같으면 최대 부분 문자열 개수가 늘어나므로, 그 이전 문자들 까지의 최대 부분 문자열 개수에 1을 더해주면 됨.
8. 여기까지 해봤을 때, 다음과 같이 나타낼 수 있음.
    i) str1[i] == str2[j] -> dp[i][j] += dp[i-1][j-1]+1
    ii) str1[i] != str2[j] -> dp[i][j] = max(dp[i-1][j], dp[i][j-1])
9. 마지막 dp의 값이 답이 됨.

![111111](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/03f5b2dc-b5ee-4493-904f-ffb0e539418b)


시간 복잡도 분석
DP를 2차 배열에 사용하여 이중 for문을 사용하므로 O(n^2)임.

후기
DP 문제한테 혼나고 왔습니다 ㅠㅜ 학부생때 알고리즘 시간에 접했던 문제인데 이상하게 접근해 버려서 틀리고 블로그 참고 하고 왔습니다 ㅎㅎ...

고생하셨습니다!! 내일이 지나면 금요일은 방학이래요! 화이팅입니다~!