### PR TITLE
조성윤 / 7월 3~4일 / 2문제

### DIFF
--- a/syJoh/BOJ/AC.py
+++ b/syJoh/BOJ/AC.py
@@ -1,0 +1,94 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+t = int(input())
+while t>0:
+    p = input().strip() #수행할 함수
+    n = int(input().strip()) #배열 개수
+    arr = input().strip()
+    q = deque(arr[1:-1].split(","))
+    if n==0:
+        q = []
+    rcount = 0
+    flag = True
+    for i in p:
+        if i == "R":
+          rcount += 1
+        elif i == "D":
+          if len(q) == 0:
+            flag = False
+            break
+          else:
+            if rcount%2==0:
+              q.popleft()
+            else:
+              q.pop()
+    if flag:
+        if rcount%2!=0 :
+            q.reverse()
+        print("["+",".join(list(q))+"]")
+    else:
+        print("error")
+    t-=1
+"""
+import java.io.*;
+import java.util.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException{
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+        int t = Integer.parseInt(br.readLine());
+        while(t>0){
+            String[] pList = br.readLine().split("");//함수
+            int n = Integer.parseInt(br.readLine());
+            Deque<Integer> q = new LinkedList<>();
+            String str = br.readLine(); //배열 형태의 정수
+            String[] arr = {};
+            if(n!=0){
+                arr = str.substring(1, str.length()-1).split(",");
+            }
+            for(int i=0; i<arr.length; i++){
+                q.add(Integer.parseInt(arr[i]));
+            }
+            boolean isRotated = false;
+            boolean flag = true;
+            for(String p : pList){
+                if(p.equals("R")){
+                    isRotated = !isRotated;
+                }else if(p.equals("D")){
+                    if(q.isEmpty()){
+                        flag = false;
+                        break;
+                    }
+                    if(isRotated){
+                        q.pollLast();
+                    }else{
+                        q.pollFirst();
+                    }
+                }
+            }
+            if(flag){
+                if(isRotated){ //홀수일 경우 회전
+                    List<Integer> list = new ArrayList<>(q);
+                    Collections.reverse(list);
+                    q = new LinkedList<>(list);
+                }
+                sb.append("[");
+                while(q.size()>1){
+                    sb.append(q.poll()+",");
+                }
+                if(q.peek()!=null) {
+                    sb.append(q.poll());
+                }
+                sb.append("]\n");
+            }else{
+                sb.append("error\n");
+            }
+            t--;
+        }
+        br.close();
+        System.out.print(sb);
+    }
+}
+"""

--- a/syJoh/BOJ/회전하는 큐.py
+++ b/syJoh/BOJ/회전하는 큐.py
@@ -1,0 +1,60 @@
+from collections import deque
+import sys
+input = sys.stdin.readline
+n, m = map(int, input().split())
+num_list = list(map(int, input().split()))
+q = deque(range(1, n+1))
+count = 0
+
+#search
+for num in num_list:
+    idx = q.index(num)
+    if idx <= len(q)//2:
+        q.rotate(-idx)
+        count += idx
+    else:
+        q.rotate(len(q)-idx)
+        count += len(q) - idx
+    q.popleft()
+print(count)
+
+"""
+import java.util.*;
+import java.io.*;
+
+class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+        LinkedList<Integer> q = new LinkedList<>();
+        for(int i=1; i<=n; i++){
+            q.add(i);
+        }
+        int[] numList = new int[m];
+        st = new StringTokenizer(br.readLine());
+        for(int i=0; i<m; i++){
+            numList[i] = Integer.parseInt(st.nextToken());
+        }
+        int count=0;
+        for(int num: numList){
+            int idx = q.indexOf(num);
+            if(idx<=q.size()/2){
+                for(int i=0; i<idx; i++){
+                    q.offerLast(q.pollFirst());
+                    count++;
+                }
+            }else{
+                for(int i=0; i<q.size()-idx; i++){
+                    q.offerFirst(q.pollLast());
+                    count++;
+                }
+            }
+            q.pollFirst();
+        }
+        br.close();
+        System.out.println(count);
+    }
+}
+"""


### PR DESCRIPTION

**1. 회전하는 큐**
- Python3
  - 덱의 가장 왼쪽 값(q[0])이 num이면 pop
  - 찾으려고 하는 num의 인덱스를 구하고 해당 인덱스만큼 회전 및 연산 횟수 증가
- Java11
  - LinkedList를 구현하여 양 옆에서 데이터 삽입, 삭제
  - 파이썬의 rotate() 대신 해당 인덱스만큼 반복문 활용

**2. AC**
- Python3
  - R이 나올 때마다 회전할 경우, 시간초과되므로 R이 2번이면 회전 안 하는 효과
  - 배열 형태의 정수를 eval()함수를 쓰고 그대로 출력하면 출력할 때 [1,2,3]이 아니라 [1, 2, 3]으로 출력되므로 직접 join을 사용해서 공백 제거
- Java11
  - 덱을 뒤집기 위해 ArrayList에 넣고 Collections.reverse(list) 후 다시 q에 넣음
  - 반례
   ```
    1
    DR
    1
    [1]
  ```
  []이 출력되어야 하는데 [null]이 출력되서 조건 수정
  ```java
  if(q.peek()!=null) {
    sb.append(q.poll());
  }
  ```
