### PR TITLE
지승우 / 7월 4일 / 2문제

### DIFF
--- a/jeesw/BOJ/Gold/indi_BOJ_13549_숨바꼭질_3_240704.java
+++ b/jeesw/BOJ/Gold/indi_BOJ_13549_숨바꼭질_3_240704.java
@@ -1,0 +1,39 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N, K;
+    static boolean[] visited = new boolean[100001];
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        K = Integer.parseInt(st.nextToken());
+
+        dijkstra(N);
+    }
+
+    static void dijkstra(int start) {
+        PriorityQueue<int[]> pq = new PriorityQueue<>((a, b) -> a[0] - b[0]);
+        pq.offer(new int[]{0, N});
+
+        while (!pq.isEmpty()) {
+            int[] current = pq.poll();
+            int val = current[0];
+            int cur = current[1];
+
+            visited[cur] = true;
+
+            if (cur == K) {
+                System.out.println(val);
+                return;
+            }
+
+            if (cur - 1 >= 0 && !visited[cur - 1]) pq.offer(new int[]{val + 1, cur - 1});
+            if (cur + 1 <= 100000 && !visited[cur + 1]) pq.offer(new int[]{val + 1, cur + 1});
+            if (cur * 2 <= 100000 && !visited[cur * 2]) pq.offer(new int[]{val, cur * 2});
+        }
+    }
+}

--- a/jeesw/BOJ/Gold/pub_BOJ_5430_AC_240704.java
+++ b/jeesw/BOJ/Gold/pub_BOJ_5430_AC_240704.java
@@ -1,0 +1,67 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringBuilder sb = new StringBuilder();
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i < T; i++) {
+            String command = br.readLine();
+            int size = Integer.parseInt(br.readLine());
+            String inputs = br.readLine();
+
+            int cur = 0;
+            int cnt_d = 0;
+            int cnt_r = 0;
+
+            Deque<Integer> d = new ArrayDeque<>();
+
+            for (char c : command.toCharArray()) {
+                if (c == 'D') cnt_d++;
+                else cnt_r++;
+            }
+
+            if (cnt_d > size) {
+                sb.append("error\n");
+            } else if (cnt_d == size) {
+                sb.append("[]\n");
+            } else {
+                String[] nums = inputs.substring(1, inputs.length() - 1).split(",");
+                for (String num : nums) {
+                    if (!num.isEmpty()) {
+                        d.add(Integer.parseInt(num));
+                    }
+                }
+
+                for (char c : command.toCharArray()) {
+                    if (c == 'D') {
+                        if (cur == 0) d.pollFirst();
+                        else d.pollLast();
+                    } else {
+                        cur = 1 - cur;
+                    }
+                }
+
+                if (cnt_r % 2 == 1) {
+                    Deque<Integer> reversed = new ArrayDeque<>();
+                    while (!d.isEmpty()) {
+                        reversed.add(d.pollLast());
+                    }
+                    d = reversed;
+                }
+
+                sb.append('[');
+                while (!d.isEmpty()) {
+                    sb.append(d.pollFirst());
+                    if (!d.isEmpty()) sb.append(',');
+                }
+                sb.append("]\n");
+            }
+        }
+
+        System.out.print(sb);
+    }
+}


### PR DESCRIPTION
스터디 42일차 회고!

<br>

[공통 문제 Comment]

 - **AC**: Deque를 이용하여 해결하였습니다!

아이디어
1. 뒤집는 작업을 앞과 뒤에서 뺴는 연산으로 볼 수 있어, Deque를 사용하여 값들을 저장함.
2. D의 개수와 R의 개수를 각각 cnt_d와 cnt_r에 저장함.
3. size보다 삭제 연산의 개수(cnt_d)가 많으면 error를 출력함.
4. size와 삭제 연산의 개수(cnt_d)가 같으면 빈 배열 []를 출력함.
5. 뒤집힌 상태인지 나타내는 변수 cur를 만들어 뒤집혀 있다면 1을 아니라면 0을 저장함. 이 때, R이 등장할 때 마다 cur의 상태를 바꿔줌. D가 등장하면, 상태에 맞게 앞에서 뺄지 뒤에서 뺄지 정함.
6. 뒤집기 연산의 개수(cnt_r)이 홀수라면 뒤집어서 값을 저장함.
7. 저장된 값을 형식에 맞게 출력함.

시간 복잡도 분석
 - 연산의 개수를 저장할 때 O(n)만큼 소요됨.
 - Deque의 값을 뺄 때, O(n)만큼 소요됨.
 - 값을 뒤집을 때, O(n)만큼 소요됨.
 - Deque의 값을 출력할 때, O(n)만큼 소요됨.
각각의 연산은 따로 작동하므로 전체 알고리즘의 시간복잡도는 O(n)임.

후기

Deque인 거 모르고 풀었으면 더 고생했을 듯 합니다. 점점 공통문제 난이도가 올라가는게 느껴지네요.
 
<br>
<br>
<br>

[개별 문제 Comment]

 - **숨바꼭질 3**: 처음에 BFS를 시도했는데 잘 안 되서 찾아보니 다익스트라 알고리즘을 이용할 수 있었습니다. (가중치가 달라서)
[https://www.acmicpc.net/problem/13549](url)

아이디어

1. 이 문제는 0~N 까지를 인덱스로 보면 각 (인덱스 * 2) 한 부분의 연산 횟수는 증가하지 않고, (인덱스 + 1), (인덱스 - 1) 한 부분의 연산 횟수는 1 증가하는 것으로 볼 수 있음. 이것은 (인덱스, 연산 횟수)의 쌍으로 값을 저장할 수 있음. 연산 횟수를 거리로 본다면 최소 시간을 출력하는 문제이므로 최소 거리를 구하는 문제로 볼 수 있음. 또, 가중치가 다르고 음수가 아니므로 다익스트라 알고리즘을 적용할 수 있음.

2. (거리, 인덱스) 값을 담을 최소 힙 우선순위 큐 pq를 구현함. (거리, 인덱스)로 담는 이유는 거리를 기준으로 최소 힙을 유지하기 위함임.

3. N부터 출발하므로 pq에 초기 값으로 (0, N)을 담음.

4. dijkstra에서 다음을 실행함.

   - `if (현재 인덱스 - 1 >= 0 && !visited[현재 인덱스 - 1])
   pq.push({ 연산 횟수 + 1, 현재 인덱스 - 1 })`

   - `if (현재 인덱스 + 1 <= 100000 && !visited[현재 인덱스 + 1])
   pq.push({연산 횟수 + 1, 현재 인덱스 + 1})`

   - `if (현재 인덱스 * 2 <= 100000 && !visited[현재 인덱스 * 2])
   pq.push({연산 횟수 + 1, 현재 인덱스 * 2})`

5. dijkstra에서 현재 탐색하는 인덱스가 K와 같다면, 저장된 연산 횟수가 최소가 됨. 따라서 이 때의 연산 횟수를 출력함.

시간 복잡도 분석
우선순위 큐를 사용한 다익스트라 알고리즘을 사용하므로 인덱스의 개수가 n개라면, O(nlogn)의 시간 복잡도를 갖는 알고리즘임.

후기

다익스트라를 인접 리스트나 배열이 아닌 값으로만 적용 할 수 있는 방법은 생각도 못했습니다... 표기된 난이도와는 다르게 전에 풀었던 다익스트라 문제보다 더 어려운 느낌입니다. 다익스트라 그새 가물가물 해질 뻔 했는데 상기시켜 주는 문제가 등장해서 좋기도 했지만 못 풀어서 아쉽네요.

<br>
<br>
<br>

고생하셨습니다!! 행복한 3일 연휴(?)를 보내시길 바랍니다~!