### PR TITLE
이현준 / 7월 10일 / 2문제

### DIFF
--- a/HyeonjunLee/ETC/Day3_Elice_Code_Challenge.java
+++ b/HyeonjunLee/ETC/Day3_Elice_Code_Challenge.java
@@ -1,0 +1,50 @@
+package Elice;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+class Day3_Elice_Code_Challenge {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        String str = br.readLine();
+
+        int answer = 0;
+        char ch;
+
+        for (int i = str.length() - 1; i > -1; i--) {
+            ch = str.charAt(i);
+
+            // 압축된 문자열인데 숫자만 있는 경우에는 길이 출력
+            if (!str.contains("(") && !str.contains(")")) {
+                answer = str.length();
+                break;
+            }
+
+            // 압축된 문자열에 괄호가 포함되어 있는 경우 다음과 같이 처리
+            // 현재 문자가 숫자일 때만 검사
+            if (isNumber(ch)) {
+
+                // 현재 숫자 다음에 '('일 경우, 저장되어 있는 값에 현재 숫자를 곱한다.
+                if (str.charAt(i + 1) == '(') {
+                    answer *= ch - '0';
+                }
+
+                // 현재 숫자 다음에 숫자나 ')'일 경우, 단순하게 문자열의 길이가 1 늘어난다.
+                else {
+                    answer += 1;
+                }
+            }
+        }
+
+        System.out.println(answer);
+    }
+
+    // 숫자인지 괄호인지 검사하는 메소드
+    static boolean isNumber(char ch) {
+        if (ch != '(' && ch != ')') {
+            return true;
+        }
+        return false;
+    }
+}

--- a/적록색약_10026.java
+++ b/적록색약_10026.java
@@ -1,0 +1,101 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+class 적록색약_10026 {
+
+    static int n;
+    static char[][] map;
+    static boolean[][] visited;
+    static boolean redGreenBlindness = false;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        // 맵과 방문 여부 배열 초기화
+        n = Integer.parseInt(br.readLine());
+        map = new char[n][n];
+        visited = new boolean[n][n];
+
+        String temp;
+        for (int i = 0; i < n; i++) {
+            temp = br.readLine();
+            for (int j = 0; j < n; j++) {
+                map[i][j] = temp.charAt(j);
+            }
+        }
+
+        int answer = 0;
+
+        // 적록색약일 때 + 아닐 때 각 1번씩 수행
+        for (int i = 0; i < 2; i++) {
+            
+            // 모든 맵의 좌표를 돌면서 dfs() 수행
+            for (int j = 0; j < n; j++) {
+                for (int k = 0; k < n; k++) {
+                    if (dfs(j, k, map[j][k])) {
+                        answer++;
+                    }
+                }
+            }
+            
+            // 정답 출력하고 초기화
+            System.out.print(answer + " ");
+            answer = 0;
+
+            // 방문 여부 초기화 및 적록색약 여부 변경
+            visited = new boolean[n][n];
+            redGreenBlindness = true;
+        }
+    }
+
+    static boolean dfs (int x, int y, char ch) {
+        // 해당 좌표가 맵 밖이면 false 반환
+        if (x < 0 || x >= n || y < 0 || y >= n) {
+            return false;
+        }
+
+        // 해당 좌표가 이미 방문한 좌표이면 false 반환
+        if (visited[x][y]) {
+            return false;
+        }
+
+        // 적록색약이 아니면
+        if (!redGreenBlindness) {
+            
+            // 현재 좌표의 문자가 영역을 검사할 문자와 다르면 false 반환
+            // ex) 처음 탐색을 시작한 좌표의 문자가 'B'라면 'B'만 탐색하게 한다.
+            if (map[x][y] != ch) {
+                return false;
+            }
+        }
+
+        // 적록색약이면
+        else {
+
+            // 영역을 검사할 문자가 R 또는 G이고 현재 좌표의 문자가 'G'이면 false 반환
+            if ((ch == 'R' || ch == 'G') && map[x][y] == 'B') {
+                return false;
+            }
+
+            // 영역을 검사할 문자가 B이고 현재 좌표의 문자가 'R'이나 'G'이면 false 반환
+            else if ((ch == 'B') && (map[x][y] == 'R' || map[x][y] == 'G')) {
+                return false;
+            }
+        }
+
+        // 위의 조건들을 이겨내고 여기까지 왔다면 방문 처리
+        visited[x][y] = true;
+
+        // 다시 4방향으로 dfs() 수행
+        dfs(x - 1, y, ch);
+        dfs(x, y + 1, ch);
+        dfs(x + 1, y, ch);
+        dfs(x, y - 1, ch);
+
+        // 무사히 끝났다면 true 반환
+        return true;
+    }
+}


### PR DESCRIPTION
공통(1)
- 적록색약
- 풀이
(1) map과 방문 여부를 검사할 배열을 각각 초기화합니다.
(2) 맵 전체를 순회하며 dfs()를 수행해야 하는데, 문제에서는 적록색약일 때와 아닐 때 둘 다 출력해야된다는 조건이 있어서 2번 돌립니다.
(3) 구현한 dfs()는 다음과 같습니다.
(3-1) 해당 좌표가 맵 밖이면 false를 반환합니다.
(3-2) 해당 좌표가 이미 방문한 좌표이면 false를 반환합니다.
(3-3) 적록색약이 아닐 경우, 검사하고자할 문자와 현재 좌표의 문자가 다른 경우를 검사하여 다르면 false를 반환합니다.
(3-4) 적록색약이라면, 'R'과 'G'의 구분이 없습니다. 즉, 검사하고자할 문자가 'R'이나 'G'일 때는 현재 좌표의 문자가 'B'인 경우만 검사하면 됩니다. 또, 검사하고자할 문자가 'B'라면 현재 좌표의 문자가 'R'이나 'G'일 때를 검사하면 됩니다. 위의 2가지 케이스에 대해서 다르면 false를 반환합니다.
(3-5) 마지막으로 위의 모든 조건들을 이겨내고 여기까지 왔다면 해당 좌표를 방문처리하며, 해당 좌표에서 다시 4방향으로 dfs()를 수행합니다.

느낀점: 일반 탐색문제에서 '적록색약인가, 아닌가'라는 특정 조건을 추가한 것이기 때문에 BFS나 DFS를 먼저 구현해놓고, 조건문을 어떻게 작성할 지 생각하니까 생각보다 금방 풀리는 문제였던 것 같습니다.

자유(1)
- 문자열 압축 해제
- 풀이
(1) 문자열이 다음과 같은 규칙을 가지고 있습니다.
K(Q) => K: 반복 횟수(한 자리 정수) / Q: 반복할 문자열(0자리 이상의 문자열)
ex) 53(8) = 5 + 3(8) = 5 + 888 = 5888
(2) 문제를 잘 읽어보면 구하는 것은 문자열의 압축을 모두 해제했을 때의 '길이'입니다. 즉, 괄호 안의 문자열을 단순히 숫자로 생각하면 해결됩니다.
(3) 문자열의 마지막 인덱스부터 시작인덱스까지 거꾸로 검사하면서 괄호 안의 문자열 길이를 계산한 뒤에 괄호 바로 앞에 있는 숫자를 곱합니다. 그리고 그 앞에 숫자가 있다면 그 숫자는 괄호 앞의 숫자가 아니므로 단순 문자로 취급하고 1을 더합니다.
-> 정리하자면 괄호 앞의 숫자는 반복 횟수이므로 곱하는 것이고, 괄호 안의 숫자는 문자열로 생각하여 그 문자열의 길이를 더해주는 과정을 반복하는 것입니다.
(4) 3의 과정을 반복하다보면 모든 괄호가 다 풀리고 전체를 압축 해제한 문자열의 길이가 나오게 됩니다.

느낀점: 괄호 보자마자 PTSD가 왔어요,,, 그래도 이건 어떤 테스트케이스든간에 입력의 구조가 똑같아서 최근에 풀었던 괄호 문제들 보다는 쉬웠던 것 같습니다.