### PR TITLE
지승우 / 7월 11일 / 3문제

### DIFF
--- a/jeesw/BOJ/Gold/indi_BOJ_1916_최소비용_구하기_240711.java
+++ b/jeesw/BOJ/Gold/indi_BOJ_1916_최소비용_구하기_240711.java
@@ -1,0 +1,78 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static final int INF = 0x3f3f3f3f;
+    static int N, M;
+    static ArrayList<ArrayList<Pair>> graph = new ArrayList<>();
+    static int[] dist;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        N = Integer.parseInt(br.readLine());
+        M = Integer.parseInt(br.readLine());
+
+        for (int i = 0; i <= N; i++) {
+            graph.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < M; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            int cost = Integer.parseInt(st.nextToken());
+            graph.get(u).add(new Pair(v, cost));
+        }
+
+        dist = new int[N + 1];
+        Arrays.fill(dist, INF);
+
+        st = new StringTokenizer(br.readLine());
+        int start = Integer.parseInt(st.nextToken());
+        int end = Integer.parseInt(st.nextToken());
+
+        dijkstra(start, end);
+    }
+
+    static void dijkstra(int start, int end) {
+        PriorityQueue<Pair> pq = new PriorityQueue<>();
+        pq.offer(new Pair(start, 0));
+        dist[start] = 0;
+
+        while (!pq.isEmpty()) {
+            Pair current = pq.poll();
+            int cur = current.first;
+            int cost = -current.second;
+
+            if (dist[cur] < cost) continue;
+
+            for (Pair next : graph.get(cur)) {
+                int nextNode = next.first;
+                int nextCost = next.second;
+
+                if (dist[nextNode] > cost + nextCost) {
+                    dist[nextNode] = cost + nextCost;
+                    pq.offer(new Pair(nextNode, -dist[nextNode]));
+                }
+            }
+        }
+
+        System.out.println(dist[end]);
+    }
+
+    static class Pair implements Comparable<Pair> {
+        int first, second;
+
+        Pair(int first, int second) {
+            this.first = first;
+            this.second = second;
+        }
+
+        @Override
+        public int compareTo(Pair other) {
+            return Integer.compare(this.second, other.second);
+        }
+    }
+}

--- a/jeesw/BOJ/Gold/pub_BOJ_7569_토마토_240711.java
+++ b/jeesw/BOJ/Gold/pub_BOJ_7569_토마토_240711.java
@@ -1,0 +1,73 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int M, N, H;
+    static int[][][] graph = new int[100][100][100];
+    static Queue<int[]> q = new LinkedList<>();
+    static int[] dir_x = {0, 0, 0, 0, -1, 1};
+    static int[] dir_y = {0, 0, -1, 1, 0, 0};
+    static int[] dir_z = {-1, 1, 0, 0, 0, 0};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        M = Integer.parseInt(st.nextToken());
+        N = Integer.parseInt(st.nextToken());
+        H = Integer.parseInt(st.nextToken());
+
+        int res = 0;
+        boolean stop = false;
+
+        for (int i = 0; i < H; i++) {
+            for (int j = 0; j < N; j++) {
+                st = new StringTokenizer(br.readLine());
+                for (int k = 0; k < M; k++) {
+                    graph[i][j][k] = Integer.parseInt(st.nextToken());
+                    if (graph[i][j][k] == 1) {
+                        q.offer(new int[]{k, j, i});
+                    }
+                }
+            }
+        }
+
+        bfs();
+
+        for (int i = 0; i < H; i++) {
+            for (int j = 0; j < N; j++) {
+                for (int k = 0; k < M; k++) {
+                    if (graph[i][j][k] == 0) {
+                        res = 0;
+                        stop = true;
+                        break;
+                    }
+                    res = Math.max(res, graph[i][j][k]);
+                }
+                if (stop) break;
+            }
+            if (stop) break;
+        }
+
+        System.out.println(res - 1);
+    }
+
+    static void bfs() {
+        while (!q.isEmpty()) {
+            int[] current = q.poll();
+            int x = current[0], y = current[1], z = current[2];
+
+            for (int i = 0; i < 6; i++) {
+                int new_x = x + dir_x[i];
+                int new_y = y + dir_y[i];
+                int new_z = z + dir_z[i];
+                if (new_x >= 0 && new_y >= 0 && new_z >= 0 && new_x < M && new_y < N && new_z < H) {
+                    if (graph[new_z][new_y][new_x] == 0) {
+                        graph[new_z][new_y][new_x] = graph[z][y][x] + 1;
+                        q.offer(new int[]{new_x, new_y, new_z});
+                    }
+                }
+            }
+        }
+    }
+}

--- a/jeesw/ETC/EliceAlgorithmCodeChallenge2407/indi_ETC_(4일차)_트리_위의_게임_240711.java
+++ b/jeesw/ETC/EliceAlgorithmCodeChallenge2407/indi_ETC_(4일차)_트리_위의_게임_240711.java
@@ -1,0 +1,129 @@
+// 오답 9 / 10로 테스트 케이스 하나 틀림.
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static final int MIN = -99999999;
+    static ArrayList<ArrayList<Integer>> tree = new ArrayList<>();
+    static boolean[] visited;
+    static int[] dp;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st;
+
+        int n = Integer.parseInt(br.readLine());
+
+        visited = new boolean[n + 1];
+        dp = new int[n + 1];
+
+        for (int i = 0; i <= n; i++) {
+            tree.add(new ArrayList<>());
+        }
+
+        for (int i = 0; i < n - 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            int u = Integer.parseInt(st.nextToken());
+            int v = Integer.parseInt(st.nextToken());
+            tree.get(u).add(v);
+            tree.get(v).add(u);
+        }
+
+        Arrays.fill(dp, MIN);
+
+        recursion(1, 0, 0);
+
+        StringBuilder sb = new StringBuilder();
+        for (int i = 1; i <= n; i++) {
+            sb.append(dp[i] > 0 ? 1 : 0).append("\n");
+        }
+
+        System.out.print(sb);
+    }
+
+    static void recursion(int node, int lev, int parent) {
+        int cnt = 0;
+
+        if (visited[node]) {
+            return;
+        }
+
+        visited[node] = true;
+        for (int next : tree.get(node)) {
+            int next_lev = lev + 1;
+            if (parent == next) {
+                cnt++;
+                continue;
+            }
+            recursion(next, next_lev, node);
+            dp[node] = Math.max(dp[node], node - dp[next]);
+        }
+        visited[node] = false;
+        if (cnt == tree.get(node).size()) dp[node] = node;
+    }
+}
+
+
+
+// 원본 .cpp 풀이
+
+//#include <iostream>
+//#include <vector>
+//
+//#define MIN -99999999
+//
+//using namespace std;
+//
+//vector<int> tree[100001];
+//bool visited[100001];
+//int dp[100001];
+//
+//void recursion(int node, int lev, int parent);
+//
+//int main() {
+//	ios::sync_with_stdio(0);
+//	cin.tie(0);
+//
+//    int n;
+//    cin >> n;
+//
+//    for (int i = 0; i < n - 1; ++i) {
+//        int u, v;
+//        cin >> u >> v;
+//        tree[u].push_back(v);
+//        tree[v].push_back(u);
+//    }
+//
+//    fill(dp, dp + n + 1, MIN);
+//
+//    recursion(1, 0, 0);
+//
+//    for (int i = 1; i <= n; i++) {
+//        cout << (dp[i] > 0 ? 1 : 0) << "\n";
+//    }
+//
+//	return 0;
+//}
+//
+//void recursion(int node, int lev, int parent) {
+//    int cnt = 0;
+//
+//    if (visited[node]) {
+//        return;
+//    }
+//
+//    visited[node] = true;
+//    for (int i = 0; i < tree[node].size(); i++) {
+//        int next = tree[node][i];
+//        int next_lev = lev + 1;
+//        if (parent == next) {
+//            cnt++;
+//            continue;
+//        }
+//        recursion(next, next_lev, node);
+//        dp[node] = max(dp[node], node - dp[next]);
+//    }
+//    visited[node] = false;
+//    if (cnt == tree[node].size())   dp[node] = node;
+//}


### PR DESCRIPTION
스터디 48일차 회고!

<br>

[공통 문제 Comment]

**토마토**: BFS를 이용하여 해결하였습니다.

[https://www.acmicpc.net/problem/7569](url)

아이디어
1. 3차원 배열을 이용해서 토마토 정보를 저장하고, 6방향을 dir_x, dir_y, dir_z 배열로 나타냄.
2. 3차원 배열을 for문으로 탐색하며 1인경우 큐에 push.
3. 3차원 배열을 bfs 탐색하며 익지 않은 토마토가 들어있는 0이라면 하루가 지나야 하니 다음 노드에 현재 노드의 값에 +1 한 값을 저장함.
4. 각 인덱스를 순회하면서 0이면 break하고 res=0을 해주고, 아닐 경우엔 각 인덱스의 최대값을 res로함.
5. res 출력.

시간 복잡도 분석

그래프의 크기(3차 배열의 인덱스 개수)를 n이라 한다면, BFS를 수행하며 O(n)의 시간복잡도를 갖는 알고리즘임.

후기

3차원 배열이라 위 아래가 추가된 거 처리만 했습니다! 축이 3개라 어질어질하네요!

<br>

<br>
<br>

[개별 문제 Comment]
**최소비용 구하기**: 다익스트라 알고리즘을 이용하여 해결했습니다.

아이디어
1. 양수인 가중치가 있는 그래프에서 최소 비용을 구하는 문제이므로 O(nlogn)의 시간 복잡도를 갖는 다익스트라 알고리즘이 적합함.
2. 단방향 그래프이고 그래프에는 각 시작점마다 (도착점, 가중치)의 쌍으로 arraylist(vector)에 저장하고, 거리를 저장할 dist배열을 대충 큰 값으로 초기화 해줌.
3. dp에서 logn만큼의 탐색을 위해 우선순위 큐를 사용하여 bfs를 구현하면 다익스트라를 사용할 수 있음. 이 때, 우선순위 큐는 (가중치, 노드 위치)의 쌍으로 값을 저장함.
4. 순회에서 현재 거리가 가중치보다 작다면 무시(continue)하는 식으로 수행 시간을 줄임.
5. 방문체크는 다음노드의 거리가 현재 가중치에서 다음 가중치를 더한 값이 큰 지로 체크함.
6. 입력받은 도착점의 가중치를 저장한 dist[end]를 출력함.

시간 복잡도 분석
그래프에서 정점의 개수를 n이라고 한다면, 우선순위 큐로 최소가 logn만에 앞에 나오므로 O(logn) 만큼 소요되며, 간선의 개수 m만큼 순회하므로 O(m)만큼 소요됨. 따라서, O(mlogn)만큼의 시간복잡도를 갖는 알고리즘임.
 
후기
다익스트라 알고리즘 그대로 구현하면 되서 다익스트라 연습하기 좋은 문제 중 하나인 것 같습니다!


<br>
<br>
<br>

 **트리 위의 게임**: dfs(백트래킹)와 dp를 사용해보았지만 테스트케이스 10개 중에 1개가 실패하였습니다.

```
트리 위의 게임

시간 제한: 1 초

정점 N개의 트리에서 두 사람이 게임을 진행하려 한다.
각 정점은 1번부터 N번 까지 번호가 매겨져 있고 루트노드는 1번 노드이다.
게임은 서로 턴을 번갈아 가며 진행되고 트리 위에 놓을 수 있는 말과 함께 진행된다.
두 사람의 점수는 모두 0점으로 시작한다.
각 턴마다 두 사람은 다음과 같은 작업을 반복한다.
현재 말이 놓여 있는 정점의 번호만큼 자신의 점수에 더한다.
현재 말이 놓여 있는 정점의 자식 정점이 없다면 그대로 게임을 종료한다.
자식 정점이 존재한다면 자식 정점 중 원하는 자식 정점으로 말을 옮긴다.
게임이 종료되었을 때 선공의 점수가 후공의 점수보다 높거나 같다면 선공이 승리하고 아니라면 후공이 승리한다.
두 사람이 최적으로 플레이할 때, 처음 말이 놓여져 있는 정점의 번호에 따라 선공이 이기는지 후공이 이기는지 구해보자.

입력
첫째 줄에 정점의 수 N이 주어진다.
1≤N≤100000
둘째 줄부터 N−1개의 줄에 간선을 나타내는 정수 u,v가 주어진다.
1≤u,v≤N
이는 u번 정점과 v번 정점을 잇는 간선이 존재한다는 뜻이다.

출력
N개의 줄에 걸쳐 정답을 출력한다.
i번째 줄에는 말의 시작위치가 i번 정점일 때의 결과를 출력한다.
선공이 이긴다면 1을 후공이 이긴다면 0을 출력한다.

입력 예시 1
5
1 3
2 1
3 4
5 1

출력 예시 1
1
1
0
1
1

입력 예시 2
6
1 3
1 2
3 5
3 6
2 4

출력 예시 2
1
0
0
1
1
1
```

아이디어

1. 우선 들어오는 개수가 10만개라서 O(nlogn) 이하의 시간복잡도를 갖는 알고리즘으로 해결해야함. 따라서 dfs를 인덱스 별로 사용하기엔 무리가 있음. (O(n^2))
2. 경로가 겹치는 부분을 찾을 수 있는데 이것을 배열에 저장하는 dp방식을 사용할 수 있음. 또, leaf 노드 부터 위로 올라가는 식으로 값을 계산할 수 있어 백트래킹을 사용함.
3. dp배열에 각각 정점의 최대값을 담을 것임. 그를 위해 대충 작은 값으로 배열의 값을 초기화 시켜둠.
4. 2를 통해 한가지 규칙을 찾을 수 있는데, 현재 노드와 다음 노드는 서로가 최선을 다하므로 서로 방해하는 요소를 고르게 되고 이는 다음과 같이 표현할 수 있음.
   `dp[현재 노드] = max(dp[현재 노드], 현재 노드 - dp[다음 노드]);`
5. 백트래킹을하며 말단 노드 부터 실행되도록 4를 수행함.
6. dp 배열을 순회하며 각각의 값이 0보다 크면 1(선공이 좋음)을, 그렇지 않으면 0(후공이 좋음)을 출력함. 


![image](https://github.com/Ormi5-Algorithm-Study/algorithm-java/assets/41260600/2c6a0e16-637c-45b6-a5e5-ae64468b3652)


시간복잡도 분석
dfs 백트래킹 만큼의 시간복잡도를 사용하므로 각각의 정점의 개수를 n이라 한다면 트리이므로 간선은 n-1개 있고 이는 O(n)만큼 수행하는 알고리즘임을 알 수 있음.

후기
반례 제보 받습니다! 반례 남겨주시면 정말정말 감사드리겠습니다 ㅠㅜ 4~5시간은 붙잡고 풀었던거 같은데 트리 dp는 쉽지 않은거 같네요. 이 문제 해결하고 다른 비슷한 문제 더 풀어보고 싶습니다.

<br>
<br>
<br>

고생하셨습니다! 3일 휴일 D-Day!! 행복하게 보내세용~~!!