### PR TITLE
지승우 / 7월 12일~13일 / 2문제

### DIFF
--- a/jeesw/BOJ/Gold/pub_BOJ_5427_불_240713.java
+++ b/jeesw/BOJ/Gold/pub_BOJ_5427_불_240713.java
@@ -1,0 +1,94 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int w, h;
+    static Cell[][] building = new Cell[1001][1001];
+    static Queue<int[]> q = new LinkedList<>();
+    static int[] dir_x = {0, 0, -1, 1};
+    static int[] dir_y = {-1, 1, 0, 0};
+
+    static class Cell {
+        char first;
+        int second;
+
+        Cell(char first, int second) {
+            this.first = first;
+            this.second = second;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int test_case = 0; test_case < T; test_case++) {
+            Queue<int[]> tmp = new LinkedList<>();
+            
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            w = Integer.parseInt(st.nextToken());
+            h = Integer.parseInt(st.nextToken());
+
+            q.clear();
+
+            for (int i = 0; i < h; i++) {
+                String line = br.readLine();
+                for (int j = 0; j < w; j++) {
+                    char c = line.charAt(j);
+                    building[i][j] = new Cell(c, -1);
+                    if (c == '@') {
+                        q.offer(new int[]{j, i});
+                        building[i][j].second = 1;
+                    } else if (c == '*') {
+                        tmp.offer(new int[]{j, i});
+                        building[i][j].second = 0;
+                    }
+                }
+            }
+            while (!tmp.isEmpty()) {
+                q.offer(tmp.poll());
+            }
+
+            bw.write(bfs() + "\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static String bfs() {
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int cur_x = cur[0];
+            int cur_y = cur[1];
+            
+            if (building[cur_y][cur_x].first == '@') {
+                if (cur_x == 0 || cur_y == 0 || cur_x == w - 1 || cur_y == h - 1) {
+                    return String.valueOf(building[cur_y][cur_x].second);
+                }
+            }
+
+            for (int i = 0; i < 4; i++) {
+                int new_x = cur_x + dir_x[i];
+                int new_y = cur_y + dir_y[i];
+                if (new_x < 0 || new_y < 0 || new_x >= w || new_y >= h) continue;
+                if (building[new_y][new_x].first == '#') continue;
+                if (building[cur_y][cur_x].first == '@' && building[new_y][new_x].first != '*') {
+                    if (building[new_y][new_x].second > -1) continue;
+                    building[new_y][new_x].first = '@';
+                    building[new_y][new_x].second = building[cur_y][cur_x].second + 1;
+                    q.offer(new int[]{new_x, new_y});
+                } else if (building[cur_y][cur_x].first == '*') {
+                    if (building[new_y][new_x].second == 0) continue;
+                    building[new_y][new_x].first = '*';
+                    building[new_y][new_x].second = 0;
+                    q.offer(new int[]{new_x, new_y});
+                }
+            }
+        }
+        return "IMPOSSIBLE";
+    }
+}

--- a/jeesw/BOJ/Silver/pub_7562_나이트의_이동_240712.java
+++ b/jeesw/BOJ/Silver/pub_7562_나이트의_이동_240712.java
@@ -1,0 +1,59 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int l;
+    static int[][] graph = new int[301][301];
+    static int dest_x, dest_y;
+    static int[] dir_x = {1, 2, 2, 1, -1, -2, -2, -1};
+    static int[] dir_y = {2, 1, -1, -2, -2, -1, 1, 2};
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        int T = Integer.parseInt(br.readLine());
+
+        for (int test_case = 0; test_case < T; test_case++) {
+            l = Integer.parseInt(br.readLine());
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            int start = Integer.parseInt(st.nextToken());
+            int end = Integer.parseInt(st.nextToken());
+            st = new StringTokenizer(br.readLine());
+            dest_x = Integer.parseInt(st.nextToken());
+            dest_y = Integer.parseInt(st.nextToken());
+
+            for (int i = 0; i < l; i++) {
+                Arrays.fill(graph[i], -1);
+            }
+
+            bw.write(bfs(start, end) + "\n");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+
+    static int bfs(int x, int y) {
+        Queue<int[]> q = new LinkedList<>();
+        q.offer(new int[]{x, y});
+        graph[y][x] = 0;
+        while (!q.isEmpty()) {
+            int[] cur = q.poll();
+            int cur_x = cur[0];
+            int cur_y = cur[1];
+
+            if (cur_x == dest_x && cur_y == dest_y) return graph[cur_y][cur_x];
+
+            for (int i = 0; i < 8; i++) {
+                int new_x = cur_x + dir_x[i];
+                int new_y = cur_y + dir_y[i];
+                if (new_x < 0 || new_y < 0 || new_x >= l || new_y >= l || graph[new_y][new_x] > -1) continue;
+                graph[new_y][new_x] = graph[cur_y][cur_x] + 1;
+                q.offer(new int[]{new_x, new_y});
+            }
+        }
+        return -1;
+    }
+}

--- a/jeesw/ETC/EliceAlgorithmCodeChallenge2407/indi_ETC_(5일차)_수열_복원_240712.java
+++ b/jeesw/ETC/EliceAlgorithmCodeChallenge2407/indi_ETC_(5일차)_수열_복원_240712.java
@@ -1,0 +1,99 @@
+// 성공한 개수: 12 / 25    시간 초과, 오답
+
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int n;
+    static List<Integer> permutation = new ArrayList<>();
+    static Map<Integer, Integer> cnt = new HashMap<>();
+    static List<Integer> result = new ArrayList<>();
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        BufferedWriter bw = new BufferedWriter(new OutputStreamWriter(System.out));
+
+        n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < (int) Math.pow(2, n); i++) {
+            int tmp = Integer.parseInt(st.nextToken());
+            permutation.add(tmp);
+            cnt.put(tmp, cnt.getOrDefault(tmp, 0) + 1);
+        }
+
+        Collections.sort(permutation);
+
+        for (int i = 1; i <= (int) Math.pow(2, n - 1); i++) {
+            if (cnt.getOrDefault(permutation.get(i), 0) == 0) continue;
+            else {
+                result.add(permutation.get(i));
+
+                if (result.size() == n) continue;
+
+                for (int j = 1; j < i; j++) {
+                    int sum = permutation.get(i) + permutation.get(j);
+                    cnt.put(sum, cnt.getOrDefault(sum, 0) - 1);
+                }
+            }
+        }
+
+        for (int i = 0; i < n; i++) {
+            bw.write(result.get(i) + " ");
+        }
+
+        bw.flush();
+        bw.close();
+        br.close();
+    }
+}
+
+// .cpp 원본 풀이
+
+//#include <iostream>
+//#include <vector>
+//#include <map>
+//#include <cmath>
+//#include <algorithm>
+//
+//using namespace std;
+//
+//int n;
+//vector<int> permutation;
+//map<int, int> cnt;
+//vector<int> result;
+//
+//int main() {
+//    ios::sync_with_stdio(0);
+//    cin.tie(0);
+//
+//    cin >> n;
+//
+//    for (int i = 0; i < (int) pow(2, n); i++) {
+//        int tmp;
+//        cin >> tmp;
+//        permutation.push_back(tmp);
+//        cnt[tmp]++;
+//    }
+//
+//    sort(permutation.begin(), permutation.end());
+//    
+//    for (int i = 1; i <= (int) pow(2, n - 1); i++) {
+//        if (cnt[permutation[i]] == 0)   continue;
+//        else {
+//            result.push_back(permutation[i]);
+//
+//            if (result.size() == n) continue;
+//
+//            for (int j = 1; j < i; j++) {
+//                cnt[permutation[i] + permutation[j]]--;
+//            }
+//        }
+//    }
+//
+//    for (int i = 0; i < n; i++) {
+//        cout << result[i] << ' ';
+//    }
+//
+//    return 0;
+//}


### PR DESCRIPTION
스터디 49일차 ~ 50일차 회고!

<br>

[공통 문제 Comment]
- **나이트의 이동**: BFS를 이용하여 해결하였습니다.
[https://www.acmicpc.net/problem/7562](url)

아이디어

8방향을 dir_x, dir_y에 저장하고 BFS돌림.

시간 복잡도 분석

그래프의 크기가 n이라 한다면, O(n + 8n) = O(n)인 알고리즘임.

후기

8방향 bfs 문제도 신기했습니다.


<br>
<br>

<br>

 - **불**: BFS를 이용하여 해결하였습니다
[https://www.acmicpc.net/problem/5427](url)

아이디어
1. building에 그래프의 (문자, 번호 (0이면 불, -1이면 벽, 양수는 카운트))의 쌍으로 저장.
2. 불(*)보다 상근(@)이가 먼저 움직이도록 (@, 1)을 먼저 push하고, 그 이후 (*, 0)을 push함.
3. bfs돌림. 이 때, 현재 상근이인지, 불인지 판별하여 다음의 과정을 거침.
   3-1) 현재 상근이(@)이라면, 불(*)을 만났을 때는 continue하고, 다음 값을 (@, 지금 count + 1) 로 변경함. 그리고 다음 방향 push함.
   3-2) 현재 불(*)이라면, 다음 값을 (*, 0) 으로 변경함. 그리고 다음 방향 push함.
4. 만약, 지금 상근(@)이가 끝에 위치해 있다면, 지금 갖고있는 second값인 빌딩 탈출의 최단 경로를 출력하고 return함.
5. bfs 탐색이 끝난다면, return이 안 될 때 해당 부분이 실행되므로, IMPOSSIBLE을 출력함.

시간 복잡도 분석
그래프의 크기가 n이라 한다면, O(n + 4n) = O(n)인 알고리즘임.

후기 
반례 지옥을 맛본거 같아요. 알고보니 building.second 처리를 따로 해주지 않고 처음에 -1 보다 크면 continue해서 작동하지 않았습니다. 오늘 발견하고 고치니 잘 작동했습니다. 불!도 풀어봐야겠습니다.


<br>
<br>
<br>

[개별 문제 Comment]
 - **수열 복원**: 맵을 이용해서 시도해봤는데 틀렸습니다.

```
수열 복원

시간 제한: 1 초
양의 정수로 이루어진 수열 a1, a2, ⋯, an 이 있습니다.

1≤ ai ≤10^5
 
이 수열에서 각 원소를 선택하거나 선택하지 않음으로써 총 2^n개의 부분 수열을 만들 수 있고, 만들어진 모든 부분 수열의 합인 2^n개의 정수가 주어졌을 때, 원래의 수열 a1, a2, ⋯, an을 구하는 프로그램을 작성하세요.

지시사항

입력
첫째 줄에 정수 n이 주어집니다.
1≤n≤15
둘째 줄에 이 수열에서 만들 수 있는 모든 부분 수열의 합인 2^n개의 정수 s1, s2, ⋯, s2n이 주어집니다.
0≤ si ≤n×10^5
 
출력
첫째 줄에 원래 수열의 원소를 오름차순으로 출력합니다.
입력 예시
3
1 4 7 3 0 6 5 2

출력 예시
1 2 4
```

틀린 문제지만 올려보았습니다. 시간 초과와 오답이 떠서 다시 풀어봐야 할 문제입니다.

후기
알고리즘 공부가 재미는 있는데 어렵네요


<br>
<br>

<br>


고생하셨습니다! 좋은 일 가득하시길 바랍니다.