### PR TITLE
이현준 / 7월 15일 / 1문제

### DIFF
--- a/HyeonjunLee/BOJ/Gold/벽부수고이동하기_2206.java
+++ b/HyeonjunLee/BOJ/Gold/벽부수고이동하기_2206.java
@@ -71,7 +71,7 @@ public class 벽부수고이동하기_2206 {
                     visited[destroy][nx][ny] = true;
                     queue.offer(new int[]{nx, ny, dist + 1, destroy});
                 } else {
-                    // 다음 칸이 벽이면서 지금까지 한 번도 벽을 부수지 않았고, 벽을 부순 방문 배열에서 방문한 경우
+                    // 다음 칸이 벽이면서 지금까지 한 번도 벽을 부수지 않았고, 벽을 부순 방문 배열에서 방문하지 않은 경우
                     if (destroy == 0 && !visited[destroy + 1][nx][ny]) {
                         visited[destroy + 1][nx][ny] = true;
                         queue.offer(new int[]{nx, ny, dist + 1, destroy + 1});

--- a/HyeonjunLee/BOJ/Gold/벽부수고이동하기_2206.java
+++ b/HyeonjunLee/BOJ/Gold/벽부수고이동하기_2206.java
@@ -1,0 +1,83 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.StringTokenizer;
+
+public class 벽부수고이동하기_2206 {
+
+    static int n, m;
+    static int[][] map;
+    static boolean[][][] visited;
+    static Queue<int[]> queue = new LinkedList<>();
+    static int[] xDirection = {-1, 0, 1, 0};
+    static int[] yDirection = {0, 1, 0, -1};
+    static int total = -1;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int[n][m];
+
+        // 벽을 부쉈을 때, 안 부쉈을 때의 경우를 동시에 계산하기 위해 3차원 배열 선언
+        visited = new boolean[2][n][m];
+
+        for (int i = 0; i < n; i++) {
+            String temp = br.readLine();
+            for (int j = 0; j < m; j++) {
+                map[i][j] = temp.charAt(j) - '0';
+            }
+        }
+
+        // {x, y, distance, destroy}
+        queue.offer(new int[]{0, 0, 1, 0});
+        visited[0][0][0] = true;
+
+        bfs();
+
+        System.out.println(total);
+    }
+
+    static void bfs() {
+
+        while (!queue.isEmpty()) {
+            int[] now = queue.poll();
+            int x = now[0];
+            int y = now[1];
+            int dist = now[2];
+            int destroy = now[3];
+
+            // 끝까지 갔으면 거리 반환
+            if (x == n - 1 && y == m - 1) {
+                total = dist;
+                return;
+            }
+
+            for (int i = 0; i < 4; i++) {
+                int nx = x + xDirection[i];
+                int ny = y + yDirection[i];
+
+                if (nx < 0 || nx >= n || ny < 0 || ny >= m) {
+                    continue;
+                }
+
+                // 다음 칸이 길이면서 벽을 부수지 않은 방문 배열에서 방문하지 않은 경우
+                if (map[nx][ny] == 0 && !visited[destroy][nx][ny]) {
+                    visited[destroy][nx][ny] = true;
+                    queue.offer(new int[]{nx, ny, dist + 1, destroy});
+                } else {
+                    // 다음 칸이 벽이면서 지금까지 한 번도 벽을 부수지 않았고, 벽을 부순 방문 배열에서 방문한 경우
+                    if (destroy == 0 && !visited[destroy + 1][nx][ny]) {
+                        visited[destroy + 1][nx][ny] = true;
+                        queue.offer(new int[]{nx, ny, dist + 1, destroy + 1});
+                    }
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
공통(1)
- 벽 부수고 이동하기
- 풀이
(1) 벽을 부술 때, 안 부술 때 나눠서 계산해야 하는 문제입니다. 왜냐하면 어떤 특정칸에 도달하기 직전의 칸들 중에서 벽을 부수고 온 분신보다는 벽을 안 부수고 온 분신으로 bfs를 진행하는게 유리하기 때문입니다.
(2) 다음 칸이 길이고, 벽을 안 부쉈을 경우에서 방문하지 않은 경우, 해당 칸을 방문처리해주고 해당 좌표를 큐에 넣습니다.
(3) 다음 칸이 벽이고, 벽을 지금까지 한 번도 안 부쉈고, 벽을 부순 경우에서 방문하지 않은 경우, 해당 칸의 벽을 부수고, 방문 처리 및 해당 칸을 큐에 넣습니다.
(4) 2와 3의 과정을 반복하면서 큐가 비게 되면 거리를 반환합니다. 만약 큐가 다 비었는데 끝까지 도착하지 못했으면 -1을 출력합니다.

느낀점: 문제에서 숨겨진 조건들은 처음에 다 생각이 났는데, 3차원 배열로 풀 생각은 전혀 못했네요... 처음에는 2차원 배열로 풀이하다가 조건을 어떻게 구현해야될지 막막했는데 지금 생각해보니까 2차원 맵 하나에 2차원 방문 배열 2개(벽 부쉈을 때, 안 부쉈을 때)를 만들었으면 풀렸겠다는 느낌이 ㅠ 다음에 다시한 번 풀어보겠습니다!