### PR TITLE
이현준 / 7월 18일 / 2문제

### DIFF
--- a/HyeonjunLee/BOJ/Gold/빙산_2573.java
+++ b/HyeonjunLee/BOJ/Gold/빙산_2573.java
@@ -1,0 +1,201 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+import java.util.Queue;
+
+public class 빙산_2573 {
+
+    static int n, m;
+    static int[][] map;
+    static Queue<Integer> melting = new LinkedList<>(); // 해당 위치에서 녹일 얼음의 높이를 저장하는 큐
+    static List<int[]> ice = new ArrayList<>(); // 얼음의 위치를 저장하는 리스트
+    static Queue<int[]> temp = new LinkedList<>(); // 매번 bfs 수행 시 방문할 얼음의 위치를 저장하는 임시 큐
+    static boolean[][] visited;
+    static int[] xDirection = {-1, 0, 1, 0};
+    static int[] yDirection = {0, 1, 0, -1};
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        n = Integer.parseInt(st.nextToken());
+        m = Integer.parseInt(st.nextToken());
+        map = new int[n][m];
+        visited = new boolean[n][m];
+
+        // 맵 초기화 및 얼음 위치를 배열에 추가
+        for (int i = 0; i < n; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 0; j < m; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+                if (map[i][j] > 0) {
+                    ice.add(new int[]{i, j});
+                }
+            }
+        }
+
+        // count: 한 번의 bfs()를 수행할 때마다 카운트
+        // answer: 정답
+        // isEnd: 얼음이 2덩어리를 체크하자마자 종료하는 조건
+        int count = 0, answer = 0;
+        boolean isEnd = false;
+
+        // 얼음이 다 녹을 때까지
+        while (!ice.isEmpty()) {
+
+            // 녹일 얼음의 높이 계산
+            for (int[] pos : ice) {
+                melt(pos[0], pos[1]);
+            }
+
+            // 얼음을 녹임
+            for (int[] pos : ice) {
+                if (!melting.isEmpty()) {
+                    map[pos[0]][pos[1]] -= melting.poll();
+                    if (map[pos[0]][pos[1]] < 0) map[pos[0]][pos[1]] = 0;
+                }
+            }
+
+            // 얼음을 녹인 후 정답 카운트 + 1
+            answer++;
+
+            // 현재 녹아서 0(물)이된 얼음 제거
+            checkIce();
+
+            // 매 bfs() 수행 시 조사할 얼음의 위치를 임시 변수에 복사
+            copyIce();
+
+            // 현재 살아있는 얼음들의 모든 위치에 대해 bfs() 수행
+            for (int[] pos : ice) {
+
+                // 이미 방문한 얼음이면 건너뜀
+                if (visited[pos[0]][pos[1]]) continue;
+
+                // bfs탐색에 성공했으면 얼음 한 덩어리 추가
+                if (bfs(pos[0], pos[1])) {
+                    count++;
+                }
+
+                // 아직 얼음이 2덩어리 이상 발견하지 못했고, 조사하지 않은 얼음이 있으면 건너뜀
+                if (count < 2 && !temp.isEmpty()) continue;
+
+                // 얼음 2덩어리를 발견하자마자 탐색 종료
+                if (count == 2) {
+                    isEnd = true;
+                    break;
+                }
+            }
+
+            // 종료 조건이 true이면 반복문 탈출
+            if (isEnd) break;
+
+            // 얼음을 녹이고, 탐색하는 과정이 끝났는데 아직 종료가 안되었다면
+            // 다시 얼음을 녹이고, 탐색하는 과정을 수행하기 위해 변수 초기화
+            count = 0;
+
+            melting.clear();
+            visited = new boolean[n][m];
+        }
+
+        if (isEnd) {
+            System.out.println(answer);
+        } else {
+            System.out.println(0);
+        }
+
+    }
+
+    // 얼음 사르르 녹이는 메소드
+    static void melt(int x, int y) {
+
+        int nx, ny, count = 0;
+
+        for (int i = 0; i < 4; i++) {
+            nx = x + xDirection[i];
+            ny = y + yDirection[i];
+
+            if (nx < 0 || nx >= n || ny < 0 || ny >= m) {
+                continue;
+            }
+
+            if (map[nx][ny] == 0) {
+                count++;
+            }
+        }
+
+        melting.offer(count);
+    }
+
+    // 하나의 덩어리를 모두 방문하는 메소드
+    static boolean bfs(int x, int y) {
+
+        // 해당 좌표가 물이면 false 반환
+        if (map[x][y] == 0) return false;
+
+        // bfs를 위한 큐를 만들고, 방문 처리
+        Queue<int[]> queue = new LinkedList<>();
+        queue.offer(new int[]{x, y});
+        visited[x][y] = true;
+        temp.poll();
+
+        int nx, ny, dx, dy;
+        int[] xy;
+        while (!queue.isEmpty()) {
+
+            xy = queue.poll();
+            dx = xy[0];
+            dy = xy[1];
+
+            for (int i = 0; i < 4; i++) {
+                nx = dx + xDirection[i];
+                ny = dy + yDirection[i];
+
+                if (nx < 0 || nx >= n || ny < 0 || ny >= m) {
+                    continue;
+                }
+
+                if (visited[nx][ny]) {
+                    continue;
+                }
+
+                if (map[nx][ny] == 0) {
+                    continue;
+                }
+
+                visited[nx][ny] = true;
+                temp.poll();
+                queue.offer(new int[]{nx, ny});
+            }
+        }
+
+        return true;
+    }
+
+    // 다 녹은 얼음 제거
+    static void checkIce() {
+        if (ice.isEmpty()) return;
+
+        int x, y, i = 0;
+        while (i < ice.size()) {
+            x = ice.get(i)[0];
+            y = ice.get(i)[1];
+
+            if (map[x][y] == 0) {
+                ice.remove(i);
+                i--;
+            }
+            i++;
+        }
+    }
+
+    // 얼음의 현재 위치를 bfs를 수행하기 위한 임시 큐에 복사
+    static void copyIce() {
+        temp.clear();
+        for (int i = 0; i < ice.size(); i++) {
+            temp.offer(ice.get(i));
+        }
+    }
+}

--- a/HyeonjunLee/BOJ/Silver/역원소정렬_5648.java
+++ b/HyeonjunLee/BOJ/Silver/역원소정렬_5648.java
@@ -1,0 +1,54 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.*;
+
+public class 역원소정렬_5648 {
+
+    static int n;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        List<Long> numbers = new ArrayList<>();
+
+        String line;
+        int i = 0;
+
+        // 첫 입력 시에만 입력 받는 횟수 지정
+        while((line = br.readLine()) != null) {
+            StringTokenizer st = new StringTokenizer(line);
+            if (i == 0 && st.hasMoreTokens()) {
+                n = Integer.parseInt(st.nextToken());
+                i++;
+            }
+
+            while (st.hasMoreTokens() && i < n + 1) {
+                numbers.add(reverseNumber(st.nextToken()));
+                i++;
+            }
+
+            if (i == n + 1) break;
+        }
+
+        Collections.sort(numbers);
+        for (long num : numbers) {
+            System.out.println(num);
+        }
+
+    }
+
+    // 숫자 뒤집기
+    static Long reverseNumber(String str) {
+
+        String newStr = "";
+
+        for (int i = str.length() - 1; i > -1; i--) {
+            newStr += str.charAt(i);
+        }
+
+        return Long.parseLong(newStr);
+    }
+}


### PR DESCRIPTION
공통(2)
- 빙산(7월 17일 문제)
- 풀이
(1) melt(): 매 시간마다 녹일 얼음의 양 계산
(2) checkIce(): 다 녹은 얼음을 큐에서 제거
(3) copyIce(): bfs()를 수행할 때 마다 아직 방문하지 않은 얼음의 개수를 얻기 위해 임시 얼음 큐에 현재 얼음 위치 복사
(4) bfs(): 하나의 얼음덩어리를 탐색
(5) (1) ~ (4)의 과정을 반복합니다. 먼저 (1) ~ (2)를 통해 매 시간마다 얼음을 녹입니다. (3)의 과정은 매 시간마다 얼음의 위치를 알아야 하는데, 이를 원본 얼음 큐에서 방문한 위치를 하나씩 빼게 되면 다음 반복문 수행이 불가능합니다. 따라서 임시 큐에 복사하는 것입니다. (4) 얼음을 녹인 뒤, 현재 얼음이 남아있는 모든 좌표에 bfs()를 수행합니다.
(6) 만약, 한 타임에서 bfs가 2번 이상 정상 동작했다면 얼음이 최소 2덩어리 이상인 것으로 간주하여 종료합니다.

느낀점: 문제만 보면 쉬울 줄 알았는데, 생각보다 조건이 너무 까다로운 문제였습니다. n의 크기에 고려하여 변수 타입을 잘 정해야 된다는 것을 뼈저리게 느꼈습니다... 저는 습관처럼 제 편의를 위해 x, y좌표가 나오는 문제면 모든 변수를 map으로 만들었는데, 이게 n이 커지면 커질수록 map의 모든 좌표를 탐색하는게 문제가 되더라구요. 잘못된 습관 고치겠습니다.

- 역원소 정렬(7월 18일 문제)
- 풀이
(1) reverseNumber(): 숫자를 뒤집어서 반환
(2) 입력을 깔끔하게 받는 문제가 아니라서, 일단 while을 이용하여 읽은 줄이 null이 아닐 때까지 입력을 받습니다.
(3) 입력을 받을 때 맨 첫 숫자만 n으로 따로 넣어주고, 그 이후의 숫자는 거꾸로 뒤집어서 리스트에 추가합니다.
(4) 정렬하여 출력합니다.

느낀점: 이거 문제 중간에 빈 줄이 있는 경우도 있는 것 같습니다. 입력받는 while문에서 처음에 조건을 (line = br.readLine()) != null && !line.isEmpty())로 했는데, 이렇게 하면 중간에 비어있는(null이 아닌 "") 문자열을 허용하지 않습니다. 이렇게 해놓고 테스트케이스를 넣을 수 있는 거 다 해봐서 잘 나왔는데 제출할 때 자꾸 막혀서 뭐가 문제인지 모르겠더라구요... 그래서 이 문제에 대해 다른 분들이 질문했던 것들 보니깐 어떤 글에서 '중간에 빈 줄이 있는 경우가 존재한다'라는 말이 있어서 바로 입력받는 조건 수정해서 제출했더니 성공했네요... ~~억까진짜 하...~~

텀 프로젝트는 내일 풀어볼게요... ㅠ