### PR TITLE
지승우 / 7월 22일 / 1문제

### DIFF
--- a/jeesw/BOJ/Silver/pub_BOJ_2910_빈도_정렬_240722.java
+++ b/jeesw/BOJ/Silver/pub_BOJ_2910_빈도_정렬_240722.java
@@ -1,0 +1,50 @@
+import java.util.*;
+import java.io.*;
+
+public class Main {
+    static int N, C;
+    static Map<Integer, Pair<Integer, Integer>> map = new HashMap<>();
+
+    static class Pair<T, U> {
+        T first;
+        U second;
+
+        Pair(T first, U second) {
+            this.first = first;
+            this.second = second;
+        }
+    }
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        N = Integer.parseInt(st.nextToken());
+        C = Integer.parseInt(st.nextToken());
+
+        st = new StringTokenizer(br.readLine());
+        for (int i = 1; i <= N; i++) {
+            int tmp = Integer.parseInt(st.nextToken());
+            map.putIfAbsent(tmp, new Pair<>(0, 0));
+            Pair<Integer, Integer> p = map.get(tmp);
+            map.put(tmp, new Pair<>(p.first + 1, p.second == 0 ? i : p.second));
+        }
+
+        List<Map.Entry<Integer, Pair<Integer, Integer>>> list = new ArrayList<>(map.entrySet());
+
+        list.sort((a, b) -> {
+            if (a.getValue().first.equals(b.getValue().first))
+                return a.getValue().second.compareTo(b.getValue().second);
+            return b.getValue().first.compareTo(a.getValue().first);
+        });
+
+        StringBuilder sb = new StringBuilder();
+        for (Map.Entry<Integer, Pair<Integer, Integer>> entry : list) {
+            for (int j = 0; j < entry.getValue().first; j++) {
+                sb.append(entry.getKey()).append(" ");
+            }
+        }
+
+        System.out.println(sb);
+    }
+}


### PR DESCRIPTION
스터디 54일차 회고!

<br>

[공통 문제 Comment]
 - **빈도 정렬**: HashMap을 사용하였습니다.
 [https://www.acmicpc.net/problem/2910](url)

아이디어
1. HashMap을 <Integer, Pair<Integer, Integer>> 형태로 구현하여 (값, (값의 개수, 처음 들어오는 시작 인덱스))의 쌍으로 값을 저장함. 
2. 같은 형식의 ArrayList로 HashMap에 저장된 값들을 받음.
3. 우선 값의 개수를 기준으로 내림차순으로 정렬하면서, 값의 개수가 같을 땐 처음 들어오는 시작 인덱스의 위치를 기준으로 오름차순 정렬함.
4. 정렬된 ArrayList의 값들을 순회하며 값의 개수만큼 출력함.

시간 복잡도 분석
값들의 길이를 n이라고 한다면, HashMap을 채우는데 O(n)만큼, ArrayList를 채우는데 O(n)만큼 소요됨. ArrayList 정렬을 할 때 O(nlogn), 출력할 때 O(n) 만큼 소요됨. 각각은 따로 실행되므로 O(nlogn)의 시간복잡도를 가짐.

후기
HashMap을 이용한 문제로 Pair를 활용하여 해결 해 봤습니다. 이런 문제를 분명 전에 프로그래머스에서 푼 기억이 있었는데 그땐 어떻게 해결했었는지 PR내용을 다시 찾아봐야겠습니다.

<br>
<br>
<br>

화이팅입니다! 항상!