### PR TITLE
이현준 / 7월 24일 / 1문제

### DIFF
--- a/HyeonjunLee/BOJ/Silver/정수삼각형_1932.java
+++ b/HyeonjunLee/BOJ/Silver/정수삼각형_1932.java
@@ -1,0 +1,66 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 정수삼각형_1932 {
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[][] num = new int[n][n];
+        int[][] dp = new int[n][n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            for (int j = 0; j <= i; j++) {
+                num[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // dp 계산을 위해 0번째 줄은 삼각형의 맨 위의 수를 입력 받는다.
+        dp[0][0] = num[0][0];
+
+        // 1번째 줄 부터 부터 계산 ~
+        for (int i = 1; i < n; i++) {
+            for (int j = 0; j <= i; j++) {
+
+                // 현재 줄에서 가장 왼쪽일 때는 바로 위의 수밖에 올 수 없다.
+                if (j == 0) {
+                    dp[i][j] = dp[i-1][j] + num[i][j];
+                    continue;
+                }
+
+                // 현재 줄에서 1 ~ n-1번째 수까지는 올 수 있는 경로가 2개이다.
+                // 두 경로중에서 더 큰 경로를 택한다.
+                if (j < i) {
+                    dp[i][j] = Math.max(dp[i-1][j-1], dp[i-1][j]) + num[i][j];
+                    continue;
+                }
+
+                // 현재 줄에서 가장 오른쪽일 때는 바로 왼쪽 위의 수밖에 올 수 없다.
+                if (j == i) {
+                    dp[i][j] = dp[i-1][j-1] + num[i][j];
+                }
+            }
+        }
+
+        // dp의 마지막 줄에서 가장 큰 값 출력
+        System.out.println(getMax(dp[n-1]));
+    }
+
+    static int getMax(int[] num) {
+        int res = 0;
+
+        for (int i = 0; i < num.length; i++) {
+            if (num[i] > res) {
+                res = num[i];
+            }
+        }
+
+        return res;
+    }
+}


### PR DESCRIPTION
공통(1)
- 정수 삼각형
- 풀이
(1) 정수 삼각형에서 dp의 i번째 줄을 채우려면 다음과 같은 규칙을 찾아야 합니다.
(2) i번째 줄에서 가장 왼쪽(j == 0)의 수는 i-1번째 줄에서 가장 왼쪽(j==0)의 수만 올 수 있습니다.
(3) i번째 줄에서 중간에 있는 수들은 왼쪽 위의 수 또는 바로 위의 수 중에서 더 큰 수가 올 수 있습니다.
(4) i번째 줄에서 가장 오른쪽(j==i)의 수는 i-1번째 줄에서 가장 오른쪽(j==i)의 수만 올 수 있습니다.
(5) (2), (3), (4)의 과정을 반복하면서 마지막 줄까지 채워나갑니다.
(6) (5)에서 구한 마지막 줄의 최댓값을 출력합니다.

느낀점: 이거 예전에 파이썬으로 풀었었는데 그 때는 코드가 매우 짧았던 걸로 기억나네요... 오랜만에 dp문제 푸니까 재밌었습니다