### PR TITLE
이현준 / 8월 8일, 9일, 10일 / 3문제

### DIFF
--- a/HyeonjunLee/BOJ/Silver/구간합구하기5_11660.java
+++ b/HyeonjunLee/BOJ/Silver/구간합구하기5_11660.java
@@ -1,0 +1,43 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 구간합구하기5_11660 {
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        int n = Integer.parseInt(st.nextToken());
+        int m = Integer.parseInt(st.nextToken());
+
+        int[][] map = new int[n + 1][n + 1];
+        for (int i = 1; i < n + 1; i++) {
+            st = new StringTokenizer(br.readLine());
+            for (int j = 1; j < n + 1; j++) {
+                map[i][j] = Integer.parseInt(st.nextToken());
+            }
+        }
+
+        // (x2, y2)까지의 부분합 구하기
+        for (int i = 1; i < n + 1; i++) {
+            for (int j = 1; j < n + 1; j++) {
+                map[i][j] += map[i - 1][j] + map[i][j - 1] - map[i - 1][j - 1];
+            }
+        }
+
+        // (x1, y1) ~ (x2, y2)의 부분합 = (x2, y2) - (x1 - 1, y2) - (x2, y1 - 1) + (x1 - 1, y1 - 1)
+        for (int i = 0; i < m; i++) {
+            st = new StringTokenizer(br.readLine());
+            int x1 = Integer.parseInt(st.nextToken());
+            int y1 = Integer.parseInt(st.nextToken());
+            int x2 = Integer.parseInt(st.nextToken());
+            int y2 = Integer.parseInt(st.nextToken());
+
+            System.out.println(map[x2][y2] - map[x2][y1 - 1] - map[x1 - 1][y2] + map[x1 - 1][y1 - 1]);
+        }
+    }
+}

--- a/HyeonjunLee/BOJ/Silver/연산자끼워넣기_14888.java
+++ b/HyeonjunLee/BOJ/Silver/연산자끼워넣기_14888.java
@@ -1,0 +1,85 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 연산자끼워넣기_14888 {
+
+    static int max = Integer.MIN_VALUE;
+    static int min = Integer.MAX_VALUE;
+    static int[] ops;
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        int n = Integer.parseInt(br.readLine());
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int[] arr = new int[n];
+        for (int i = 0; i < n; i++) {
+            arr[i] = Integer.parseInt(st.nextToken());
+        }
+
+        ops = new int[4];
+        st = new StringTokenizer(br.readLine());
+        for (int i = 0; i < 4; i++) {
+            ops[i] = Integer.parseInt(st.nextToken());
+        }
+
+        calc(n, arr[0], arr, 1);
+
+        System.out.println(max);
+        System.out.println(min);
+    }
+
+    public static void calc(int n, int num, int[] arr, int step) {
+
+        // 연산자를 모두 소비했을 때 max, min 계산
+        if (step == n) {
+            if (num > max) {
+                max = num;
+            }
+
+            if (num < min) {
+                min = num;
+            }
+
+            return;
+        }
+
+        // 가지고 있는 모든 연산자에 대해서 백트래킹 적용
+        for (int i = 0; i < 4; i++) {
+
+            // 연산자가 남아있으면 calc 재귀 호출
+            if (ops[i] > 0) {
+
+                // 연산자 개수 감소
+                ops[i]--;
+
+                switch (i) {
+                    case 0:
+                        calc(n, num + arr[step], arr, step + 1);
+                        break;
+
+                    case 1:
+                        calc(n, num - arr[step], arr, step + 1);
+                        break;
+
+                    case 2:
+                        calc(n, num * arr[step], arr, step + 1);
+                        break;
+
+                    case 3:
+                        calc(n, num / arr[step], arr, step + 1);
+                }
+
+                // 연산자 개수 증가(다음 경우를 계산하기 위해 개수 복구)
+                ops[i]++;
+            }
+        }
+    }
+}

--- a/HyeonjunLee/BOJ/Silver/퇴사_14501.java
+++ b/HyeonjunLee/BOJ/Silver/퇴사_14501.java
@@ -1,0 +1,52 @@
+package Bakjoon;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class 퇴사_14501 {
+
+    public static void main(String[] args) throws IOException {
+
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        int n = Integer.parseInt(br.readLine());
+        int[][] days = new int[n + 1][2];
+        int[] answer = new int[n + 1];
+
+        for (int i = 1; i < n + 1; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            days[i][0] = Integer.parseInt(st.nextToken()); // Ti
+            days[i][1] = Integer.parseInt(st.nextToken()); // Pi
+        }
+
+        for (int i = 1; i < n + 1; i++) {
+
+            // 해당일 + 상담기간이 전체기간을 넘지 않아야함
+            if (i + days[i][0] > n + 1) continue;
+
+            if (answer[i] == 0) {
+                answer[i] = days[i][1];
+            }
+
+            for (int j = i + days[i][0]; j < n + 1; j++) {
+                // 해당일 + 상담기간이 전체기간을 넘지 않아야함
+                if (j + days[j][0] > n + 1) continue;
+
+                // 해당 날짜를 포함하는 경우 중에서 기존의 금액보다 크면 값 업데이트
+                if (answer[j] < answer[i] + days[j][1]) {
+                    answer[j] = answer[i] + days[j][1];
+                }
+            }
+        }
+
+        int max = 0;
+        for (int i = 1; i < n + 1; i++) {
+            if (max < answer[i]) {
+                max = answer[i];
+            }
+        }
+
+        System.out.println(max);
+    }
+}


### PR DESCRIPTION
공통(3)
- 퇴사
- 풀이
(1) 이중 반복문을 활용하여, 바깥 반복문은 기간만큼 돌리면서 안쪽 반복문에서는 바깥 반복문에서 설정한 날짜를 상담에 포함하는 경우를 전부 계산해서 각 날짜별로 얻을 수 있는 최대 수익을 계산합니다.
(2) 예를 들어, 예시에 주어진 경우에는 1일차에 상담 기간이 3일이므로 1일차를 포함하는 경우, 4일차부터는 1일차의 금액인 10만큼 다 더합니다. 이런식으로 모든 일자를 포함하는 경우를 계산하고, 마지막에 가장 큰 값을 출력하도록 했습니다.

느낀점: 아무리 길게잡아도 15일이라는 것을 보고, 2중 반복문을 돌려도 괜찮다고 생각해서 각 날짜를 포함하는 모든 경우를 다 계산했습니다. 실버3인데도 어려웠습니다.

- 구간 합 구하기5
- 풀이
(1) 구간합 규칙을 적용하여 dp를 계산합니다. (x2, y2)까지의 구간합은 (x2 - 1, y2) + (x2, y2 - 1) - (x2 - 1, y2 - 1)입니다.
(2) (x1, y1) ~ (x2, y2)의 구간합은 (x2, y2) - (x1 - 1, y2) - (x2, y1 - 1) + (x1 - 1, y1 - 1) 입니다.

느낀점: 처음에 단순 반복문으로 풀어서 시간초과나길래 누적합을 사용해야된다는 것까지는 알았는데, (x2, y2)까지의 누적합을 구할 생각은 못했네요... 그래서 다른 분들 풀이 참고해서 해결했습니다. 실버인데 매우 어렵...

- 연산자 끼워넣기
- 풀이
(1) 보유하고 있는 모든 연산자를 사용하고, 순서도 다르게 넣는 경우까지 고려해야해서 완전 탐색 진행했습니다.
(2) 연산자를 끼워 넣을 때, 연산자 개수를 줄이고 계산 후, 다시 연산자 개수를 복구시키는 것을 계속 반복하여 모든 연산자를 끼워넣는 경우를 계산합니다.

느낀점: 완탐류의 문제는 언제 봐도 항상 어렵네요... 재귀는 너무 어렵습니다... 문제 고민하다가 도저히 답이 안떠올라서 이 문제도 다른 분들 풀이 참고해서 풀었습니다 ㅠ